### PR TITLE
Bump classgraph from 4.8.84 to 4.8.85

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Discoverer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Discoverer.java
@@ -125,17 +125,8 @@ interface Discoverer {
 
 			LOGGER.log(Level.FINE, "Scanning for classpath resources in {0}", classpathLocations);
 
-			// I'm forcing this down to the system classloader, as all the others lead wrong results
-			// Especially the current context class loader as described here
-			// https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/appendix-executable-jar-format.html#executable-jar-restrictions
-			// gives an invalid url like this
-			// jar:file:foobar/classgraph_resources_issue-0.0.1-SNAPSHOT.jar!/BOOT-INF/classes!/BOOT-INF/classes/foo/a.cypher
-			// (Twice the boot)
-			// See https://github.com/classgraph/classgraph/issues/435
-
-			try (ScanResult scanResult = new ClassGraph()
-				.overrideClassLoaders(ClassLoader.getSystemClassLoader())
-				.whitelistPaths(classpathLocations.toArray(new String[classpathLocations.size()])).scan()) {
+			String[] paths = classpathLocations.toArray(new String[classpathLocations.size()]);
+			try (ScanResult scanResult = new ClassGraph().whitelistPaths(paths).scan()) {
 
 				return scanResult.getResourcesWithExtension(Defaults.CYPHER_SCRIPT_EXTENSION)
 					.stream()

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
 		<assertj.version>3.16.1</assertj.version>
 		<checkstyle.version>8.33</checkstyle.version>
-		<classgraph.version>4.8.84</classgraph.version>
+		<classgraph.version>4.8.85</classgraph.version>
 		<graalvm.version>20.1.0</graalvm.version>
 		<java-module-name />
 		<java.version>1.8</java.version>


### PR DESCRIPTION
This removes the need for the workaround introduced with 829bb2ab2ad93d49fbba3f78a52af44a52616311.