### PR TITLE
fix: Add MANIFEST.MF to native bundle and provide a central way to retrieve the product version.

### DIFF
--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<covered-ratio-complexity>0.1</covered-ratio-complexity>
 		<covered-ratio-instructions>0.03</covered-ratio-instructions>
-		<executable-suffix />
+		<executable-suffix/>
 		<java-module-name>ac.simons.neo4j.migrations.cli</java-module-name>
 		<name-of-main-class>ac.simons.neo4j.migrations.cli.MigrationsCli</name-of-main-class>
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ManifestVersionProvider.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ManifestVersionProvider.java
@@ -15,17 +15,13 @@
  */
 package ac.simons.neo4j.migrations.cli;
 
+import ac.simons.neo4j.migrations.core.Migrations;
 import picocli.CommandLine.IVersionProvider;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.Enumeration;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 /**
  * Version provider modelled after the official example
  * <a href="https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/VersionProviderDemo2.java">here</a>
+ * Implementation has been moved to the core module, see {@literal ac.simons.neo4j.migrations.core.ProductionVersion}.
  *
  * @author Michael J. Simons
  * @soundtrack Phil Collins - ...But Seriously
@@ -34,32 +30,7 @@ import java.util.jar.Manifest;
 final class ManifestVersionProvider implements IVersionProvider {
 
 	@Override
-	public String[] getVersion() throws Exception {
-		Enumeration<URL> resources = MigrationsCli.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
-		while (resources.hasMoreElements()) {
-			URL url = resources.nextElement();
-			try {
-				Manifest manifest = new Manifest(url.openStream());
-				if (isApplicableManifest(manifest)) {
-					Attributes attr = manifest.getMainAttributes();
-					return new String[] { get(attr, "Implementation-Title") + " v" +
-						get(attr, "Implementation-Version") + "" };
-				}
-			} catch (IOException ex) {
-				return new String[] { "Unable to read from " + url + ": " + ex };
-			}
-		}
-		return new String[] { "Unknown version" };
+	public String[] getVersion() {
+		return new String[] { Migrations.getUserAgent() };
 	}
-
-	private static boolean isApplicableManifest(Manifest manifest) {
-		Attributes attributes = manifest.getMainAttributes();
-		return ManifestVersionProvider.class.getPackage().getName()
-			.equals(get(attributes, "Automatic-Module-Name"));
-	}
-
-	private static Object get(Attributes attributes, String key) {
-		return attributes.get(new Attributes.Name(key));
-	}
-
 }

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -210,12 +210,8 @@ public final class MigrationsCli implements Runnable {
 
 	Driver openConnection() {
 
-		Config driverConfig = Config.builder()
-			.withMaxConnectionPoolSize(maxConnectionPoolSize)
-			.withUserAgent(Migrations.getUserAgent())
-			.withLogging(Logging.console(Level.SEVERE)).build();
 		AuthToken authToken = AuthTokens.basic(user, new String(password));
-		Driver driver = GraphDatabase.driver(address, authToken, driverConfig);
+		Driver driver = GraphDatabase.driver(address, authToken, createDriverConfig());
 		boolean verified = false;
 		try {
 			driver.verifyConnectivity();
@@ -227,5 +223,13 @@ public final class MigrationsCli implements Runnable {
 			}
 		}
 		return driver;
+	}
+
+	Config createDriverConfig() {
+
+		return Config.builder()
+			.withMaxConnectionPoolSize(maxConnectionPoolSize)
+			.withUserAgent(Migrations.getUserAgent())
+			.withLogging(Logging.console(Level.SEVERE)).build();
 	}
 }

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -16,6 +16,7 @@
 package ac.simons.neo4j.migrations.cli;
 
 import ac.simons.neo4j.migrations.core.Defaults;
+import ac.simons.neo4j.migrations.core.Migrations;
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
 import ac.simons.neo4j.migrations.core.MigrationsConfig.TransactionMode;
 import ac.simons.neo4j.migrations.core.MigrationsException;
@@ -211,7 +212,7 @@ public final class MigrationsCli implements Runnable {
 
 		Config driverConfig = Config.builder()
 			.withMaxConnectionPoolSize(maxConnectionPoolSize)
-			.withUserAgent("neo4j-migrations")
+			.withUserAgent(Migrations.getUserAgent())
 			.withLogging(Logging.console(Level.SEVERE)).build();
 		AuthToken authToken = AuthTokens.basic(user, new String(password));
 		Driver driver = GraphDatabase.driver(address, authToken, driverConfig);

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ManifestVersionProviderTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ManifestVersionProviderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class ManifestVersionProviderTest {
+
+	@Test
+	void getVersionShouldWork() {
+
+		ManifestVersionProvider manifestVersionProvider = new ManifestVersionProvider();
+		assertThat(manifestVersionProvider.getVersion()).containsExactly(
+			"neo4j-migrations/unknown"); // No test-manifest here
+	}
+}

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ManifestVersionProviderTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ManifestVersionProviderTest.java
@@ -28,7 +28,8 @@ class ManifestVersionProviderTest {
 	void getVersionShouldWork() {
 
 		ManifestVersionProvider manifestVersionProvider = new ManifestVersionProvider();
-		assertThat(manifestVersionProvider.getVersion()).containsExactly(
-			"neo4j-migrations/unknown"); // No test-manifest here
+		String[] version = manifestVersionProvider.getVersion();
+		assertThat(version).hasSize(1);
+		assertThat(version[0]).matches("neo4j-migrations/(unknown|\\d+(?:\\.\\d+\\.\\d+)?(?:-SNAPSHOT)?)");
 	}
 }

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
@@ -148,6 +148,6 @@ class MigrationsCliTest {
 
 		Config config = cli.createDriverConfig();
 		assertThat(config.maxConnectionPoolSize()).isEqualTo(4711);
-		assertThat(config.userAgent()).isEqualTo("neo4j-migrations/unknown");
+		assertThat(config.userAgent()).startsWith("neo4j-migrations/");
 	}
 }

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
@@ -29,6 +29,7 @@ import org.graalvm.nativeimage.ImageInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.neo4j.driver.Config;
 
 /**
  * @author Michael J. Simons
@@ -134,5 +135,19 @@ class MigrationsCliTest {
 			};
 			assertThat(cmd.call()).isEqualTo(CommandLine.ExitCode.USAGE);
 		});
+	}
+
+	@Test
+	void createDriverConfigShouldSetCorrectValues() throws IllegalAccessException {
+
+		MigrationsCli cli = new MigrationsCli();
+
+		Field field = ReflectionSupport.findFields(MigrationsCli.class, f -> "maxConnectionPoolSize".equals(f.getName()), HierarchyTraversalMode.TOP_DOWN).get(0);
+		field.setAccessible(true);
+		field.set(cli, 4711);
+
+		Config config = cli.createDriverConfig();
+		assertThat(config.maxConnectionPoolSize()).isEqualTo(4711);
+		assertThat(config.userAgent()).isEqualTo("neo4j-migrations/unknown");
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -224,6 +224,14 @@ public final class Migrations {
 		});
 	}
 
+	/**
+	 * @return the user agent for Neo4j-Migrations (given in the form {@literal name/version}).
+	 * @since 1.2.1
+	 */
+	public static String getUserAgent() {
+		return "neo4j-migrations/" + ProductionVersion.getValue();
+	}
+
 	private <T> T executeWithinLock(Supplier<T> executable) {
 
 		driver.verifyConnectivity();

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductionVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductionVersion.java
@@ -61,7 +61,7 @@ final class ProductionVersion {
 			throw new MigrationsException("Unable to read from neo4j-migrations-core manifest.");
 		}
 
-		return "Unknown version";
+		return "unknown";
 	}
 
 	private static boolean isApplicableManifest(Manifest manifest) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductionVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductionVersion.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Utility class to retrieve the core modules version aka the product version.
+ *
+ * @author Michael J. Simons
+ * @since 1.2.1
+ */
+final class ProductionVersion {
+
+	private static volatile String value;
+
+	static String getValue() {
+
+		String computedVersion = value;
+		if (computedVersion == null) {
+			synchronized (ProductionVersion.class) {
+				computedVersion = value;
+				if (computedVersion == null) {
+					value = getVersionImpl();
+					computedVersion = value;
+				}
+			}
+		}
+		return computedVersion;
+	}
+
+	private static String getVersionImpl() {
+		try {
+			Enumeration<URL> resources = Migrations.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+			while (resources.hasMoreElements()) {
+				URL url = resources.nextElement();
+				Manifest manifest = new Manifest(url.openStream());
+				if (isApplicableManifest(manifest)) {
+					Attributes attr = manifest.getMainAttributes();
+					return get(attr, "Implementation-Version").toString();
+				}
+			}
+		} catch (IOException ex) {
+			throw new MigrationsException("Unable to read from neo4j-migrations-core manifest.");
+		}
+
+		return "Unknown version";
+	}
+
+	private static boolean isApplicableManifest(Manifest manifest) {
+		Attributes attributes = manifest.getMainAttributes();
+		return ProductionVersion.class.getPackage().getName()
+			.equals(get(attributes, "Automatic-Module-Name"));
+	}
+
+	private static Object get(Attributes attributes, String key) {
+		return attributes.get(new Attributes.Name(key));
+	}
+
+	private ProductionVersion() {
+	}
+}

--- a/neo4j-migrations-core/src/main/resources/META-INF/native-image/eu.michael-simons.neo4j/neo4j-migrations/resources-config.json
+++ b/neo4j-migrations-core/src/main/resources/META-INF/native-image/eu.michael-simons.neo4j/neo4j-migrations/resources-config.json
@@ -3,5 +3,10 @@
     {
       "name": "ac.simons.neo4j.migrations.core.messages"
     }
+  ],
+  "resources": [
+    {
+      "pattern": "META-INF/MANIFEST\\.MF"
+    }
   ]
 }

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ProductionVersionTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ProductionVersionTest.java
@@ -25,11 +25,11 @@ class ProductionVersionTest {
 
 	@Test
 	void getValueShouldWork() {
-		Assertions.assertThat(ProductionVersion.getValue()).isEqualTo("4711");
+		Assertions.assertThat(ProductionVersion.getValue()).isEqualTo("unknown");
 	}
 
 	@Test
 	void getUserAgentShouldWork() {
-		Assertions.assertThat(Migrations.getUserAgent()).isEqualTo("neo4j-migrations/4711");
+		Assertions.assertThat(Migrations.getUserAgent()).isEqualTo("neo4j-migrations/unknown");
 	}
 }

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ProductionVersionTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ProductionVersionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class ProductionVersionTest {
+
+	@Test
+	void getValueShouldWork() {
+		Assertions.assertThat(ProductionVersion.getValue()).isEqualTo("4711");
+	}
+
+	@Test
+	void getUserAgentShouldWork() {
+		Assertions.assertThat(Migrations.getUserAgent()).isEqualTo("neo4j-migrations/4711");
+	}
+}

--- a/neo4j-migrations-core/src/test/resources/META-INF/MANIFEST.MF
+++ b/neo4j-migrations-core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Name: This is just a test manifest and must not be included in the final jar.
+Implementation-Title: Neo4j Migrations (Core)
+Implementation-Version: 4711
+Implementation-Vendor: Neo4j, Neo4j Sweden AB
+Automatic-Module-Name: ac.simons.neo4j.migrations.core
+Multi-Release: true
+

--- a/neo4j-migrations-core/src/test/resources/META-INF/MANIFEST.MF
+++ b/neo4j-migrations-core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Manifest-Version: 1.0
-Name: This is just a test manifest and must not be included in the final jar.
-Implementation-Title: Neo4j Migrations (Core)
-Implementation-Version: 4711
-Implementation-Vendor: Neo4j, Neo4j Sweden AB
-Automatic-Module-Name: ac.simons.neo4j.migrations.core
-Multi-Release: true
-

--- a/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
+++ b/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
@@ -154,7 +154,10 @@ abstract class AbstractConnectedMojo extends AbstractMojo {
 
 	Driver openConnection() {
 
-		Config driverConfig = Config.builder().withLogging(Logging.console(Level.SEVERE)).build();
+		Config driverConfig = Config.builder()
+			.withLogging(Logging.console(Level.SEVERE))
+			.withUserAgent(Migrations.getUserAgent())
+			.build();
 		AuthToken authToken = AuthTokens.basic(user, password);
 		Driver driver = GraphDatabase.driver(address, authToken, driverConfig);
 		boolean verified = false;

--- a/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
+++ b/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
@@ -154,12 +154,8 @@ abstract class AbstractConnectedMojo extends AbstractMojo {
 
 	Driver openConnection() {
 
-		Config driverConfig = Config.builder()
-			.withLogging(Logging.console(Level.SEVERE))
-			.withUserAgent(Migrations.getUserAgent())
-			.build();
 		AuthToken authToken = AuthTokens.basic(user, password);
-		Driver driver = GraphDatabase.driver(address, authToken, driverConfig);
+		Driver driver = GraphDatabase.driver(address, authToken, createDriverConfig());
 		boolean verified = false;
 		try {
 			driver.verifyConnectivity();
@@ -171,5 +167,13 @@ abstract class AbstractConnectedMojo extends AbstractMojo {
 			}
 		}
 		return driver;
+	}
+
+	static Config createDriverConfig() {
+
+		return Config.builder()
+			.withLogging(Logging.console(Level.SEVERE))
+			.withUserAgent(Migrations.getUserAgent())
+			.build();
 	}
 }

--- a/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
+++ b/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
@@ -15,6 +15,7 @@
  */
 package ac.simons.neo4j.migrations.maven;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -35,6 +36,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.internal.logging.ConsoleLogging;
 
 /**
  * @author Michael J. Simons
@@ -126,6 +129,14 @@ public class AbstractConnectedMojoTest {
 		InfoMojo infoMojo = (InfoMojo) rule.lookupConfiguredMojo(pom, "info");
 		assertNotNull(infoMojo);
 		assertEquals(Optional.of("anotherDatabase"), infoMojo.getConfig().getOptionalSchemaDatabase());
+	}
+
+	@Test
+	public void createDriverConfigShouldSetCorrectValues() {
+
+		Config config = AbstractConnectedMojo.createDriverConfig();
+		assertThat(config.logging()).isInstanceOf(ConsoleLogging.class);
+		assertThat(config.userAgent()).isEqualTo("neo4j-migrations/unknown");
 	}
 }
 

--- a/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
+++ b/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
@@ -136,7 +136,7 @@ public class AbstractConnectedMojoTest {
 
 		Config config = AbstractConnectedMojo.createDriverConfig();
 		assertThat(config.logging()).isInstanceOf(ConsoleLogging.class);
-		assertThat(config.userAgent()).isEqualTo("neo4j-migrations/unknown");
+		assertThat(config.userAgent()).startsWith("neo4j-migrations/");
 	}
 }
 


### PR DESCRIPTION
This fixes the "unknown version" when running CLI in native mode.
Also adds the user agent when run as Maven plugin.