### PR TITLE
feat: Allow disabling of migrations in Spring Boot without removing the `Migrations` bean.

### DIFF
--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cli</artifactId>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb-testharness</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb</artifactId>

--- a/neo4j-migrations-examples/pom.xml
+++ b/neo4j-migrations-examples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples</artifactId>

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-maven-plugin</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/pom.xml
+++ b/neo4j-migrations-quarkus-parent/deployment/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-deployment</artifactId>

--- a/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
+++ b/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-integration-tests</artifactId>

--- a/neo4j-migrations-quarkus-parent/pom.xml
+++ b/neo4j-migrations-quarkus-parent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-parent</artifactId>

--- a/neo4j-migrations-quarkus-parent/runtime/pom.xml
+++ b/neo4j-migrations-quarkus-parent/runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-autoconfigure</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfiguration.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfiguration.java
@@ -46,7 +46,6 @@ import org.springframework.core.io.ResourceLoader;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Migrations.class)
 @ConditionalOnBean(Driver.class)
-@ConditionalOnProperty(prefix = "org.neo4j.migrations", name = "enabled", matchIfMissing = true)
 @AutoConfigureAfter({ Neo4jAutoConfiguration.class })
 @AutoConfigureBefore({ Neo4jDataAutoConfiguration.class })
 @EnableConfigurationProperties({ MigrationsProperties.class })
@@ -82,6 +81,7 @@ public class MigrationsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean({ MigrationsInitializer.class })
+	@ConditionalOnProperty(prefix = "org.neo4j.migrations", name = "enabled", matchIfMissing = true)
 	MigrationsInitializer neo4jMigrationsInitializer(Migrations neo4jMigrations) {
 
 		return new MigrationsInitializer(neo4jMigrations);

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationTest.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationTest.java
@@ -270,7 +270,10 @@ class MigrationsAutoConfigurationTest {
 			contextRunner
 				.withUserConfiguration(WithDriver.class)
 				.withPropertyValues("org.neo4j.migrations.enabled=false")
-				.run(ctx -> assertThat(ctx).doesNotHaveBean(Migrations.class));
+				.run(ctx -> assertThat(ctx)
+					.hasSingleBean(Migrations.class)
+					.doesNotHaveBean(MigrationsInitializer.class)
+				);
 		}
 	}
 

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>

--- a/neo4j-migrations-test-resources/pom.xml
+++ b/neo4j-migrations-test-resources/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-resources</artifactId>

--- a/neo4j-migrations-test-results/pom.xml
+++ b/neo4j-migrations-test-results/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-results</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>eu.michael-simons.neo4j</groupId>
 	<artifactId>neo4j-migrations-parent</artifactId>
-	<version>1.2.4-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Neo4j Migrations</name>


### PR DESCRIPTION
This is a breaking change in behavior and aligns the behavior of the Spring Boot starter with the Quarkus extension: Disabling migrations will just disable migrations on startup but still provide a `Migrations` bean with the given configuration. This allows for calls to `info`, `validate` and the like without manually recreating the configuration.

This closes #342.