### PR TITLE
refactor: Avoid printing a full stack trace for expected exceptions in the CLI.

### DIFF
--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
@@ -17,6 +17,7 @@ package ac.simons.neo4j.migrations.cli;
 
 import ac.simons.neo4j.migrations.core.Migrations;
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
+import ac.simons.neo4j.migrations.core.MigrationsException;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -63,7 +64,7 @@ abstract class ConnectedCommand implements Callable<Integer> {
 			Migrations migrations = new Migrations(config, driver);
 
 			return withMigrations(migrations);
-		} catch (AuthenticationException | ServiceUnavailableException e) {
+		} catch (AuthenticationException | ServiceUnavailableException | MigrationsException e) {
 			MigrationsCli.LOGGER.log(Level.SEVERE, e.getMessage());
 			return CommandLine.ExitCode.SOFTWARE;
 		}

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ExceptionHandlingTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ExceptionHandlingTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsConfig;
+import ac.simons.neo4j.migrations.core.MigrationsException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Driver;
+
+/**
+ * @author Michael J. Simons
+ */
+class ExceptionHandlingTest {
+
+	@Test // GH-421
+	void shouldCatchAndLogMigrationsException() throws Exception {
+
+		MigrationsCli cli = mock(MigrationsCli.class);
+		when(cli.getAuthToken()).thenReturn(mock(AuthToken.class));
+		when(cli.getConfig()).thenReturn(MigrationsConfig.builder().build());
+		when(cli.openConnection(Mockito.any(AuthToken.class))).thenReturn(mock(Driver.class));
+
+		ConnectedCommand cmd = new ConnectedCommand() {
+			@Override
+			MigrationsCli getParent() {
+				return cli;
+			}
+
+			@Override Integer withMigrations(Migrations migrations) {
+				throw new MigrationsException("Oh wie schade.");
+			}
+		};
+
+		String result = tapSystemOut(() -> {
+			cmd.call();
+			System.out.flush();
+		});
+		assertThat(result).isEqualTo("Oh wie schade." + System.lineSeparator());
+	}
+}

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/LoggingTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/LoggingTest.java
@@ -17,8 +17,17 @@ package ac.simons.neo4j.migrations.cli;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsConfig;
+import ac.simons.neo4j.migrations.core.MigrationsException;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Driver;
 
 /**
  * @author Michael J. Simons
@@ -33,5 +42,31 @@ class LoggingTest {
 			System.out.flush();
 		});
 		assertThat(result).isEqualTo("Test" + System.lineSeparator());
+	}
+
+	@Test // GH-421
+	void shouldCatchAndLogMigrationsException() throws Exception {
+
+		MigrationsCli cli = mock(MigrationsCli.class);
+		when(cli.getAuthToken()).thenReturn(mock(AuthToken.class));
+		when(cli.getConfig()).thenReturn(MigrationsConfig.builder().build());
+		when(cli.openConnection(Mockito.any(AuthToken.class))).thenReturn(mock(Driver.class));
+
+		ConnectedCommand cmd = new ConnectedCommand() {
+			@Override
+			MigrationsCli getParent() {
+				return cli;
+			}
+
+			@Override Integer withMigrations(Migrations migrations) {
+				throw new MigrationsException("Oh wie schade.");
+			}
+		};
+
+		String result = tapSystemOut(() -> {
+			cmd.call();
+			System.out.flush();
+		});
+		assertThat(result).isEqualTo("Oh wie schade." + System.lineSeparator());
 	}
 }

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/LoggingTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/LoggingTest.java
@@ -17,17 +17,8 @@ package ac.simons.neo4j.migrations.cli;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import ac.simons.neo4j.migrations.core.Migrations;
-import ac.simons.neo4j.migrations.core.MigrationsConfig;
-import ac.simons.neo4j.migrations.core.MigrationsException;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.neo4j.driver.AuthToken;
-import org.neo4j.driver.Driver;
 
 /**
  * @author Michael J. Simons
@@ -42,31 +33,5 @@ class LoggingTest {
 			System.out.flush();
 		});
 		assertThat(result).isEqualTo("Test" + System.lineSeparator());
-	}
-
-	@Test // GH-421
-	void shouldCatchAndLogMigrationsException() throws Exception {
-
-		MigrationsCli cli = mock(MigrationsCli.class);
-		when(cli.getAuthToken()).thenReturn(mock(AuthToken.class));
-		when(cli.getConfig()).thenReturn(MigrationsConfig.builder().build());
-		when(cli.openConnection(Mockito.any(AuthToken.class))).thenReturn(mock(Driver.class));
-
-		ConnectedCommand cmd = new ConnectedCommand() {
-			@Override
-			MigrationsCli getParent() {
-				return cli;
-			}
-
-			@Override Integer withMigrations(Migrations migrations) {
-				throw new MigrationsException("Oh wie schade.");
-			}
-		};
-
-		String result = tapSystemOut(() -> {
-			cmd.call();
-			System.out.flush();
-		});
-		assertThat(result).isEqualTo("Oh wie schade." + System.lineSeparator());
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -98,14 +98,14 @@ final class ChainBuilder {
 			try {
 				newMigration = discoveredMigrations.get(i);
 			} catch (IndexOutOfBoundsException e) {
-				String message = "More migrations have been applied to the database than locally resolved";
+				String message = "More migrations have been applied to the database than locally resolved.";
 				if (detailedCauses) {
 					throw new MigrationsException(message, e);
 				}
 				throw new MigrationsException(message);
 			}
 			if (!newMigration.getVersion().equals(expectedVersion)) {
-				throw new MigrationsException("Unexpected migration at index " + i + ": " + Migrations.toString(newMigration));
+				throw new MigrationsException("Unexpected migration at index " + i + ": " + Migrations.toString(newMigration) + ".");
 			}
 
 			if ((context.getConfig().isValidateOnMigrate() || alwaysVerify) && !expectedChecksum.equals(newMigration.getChecksum())) {

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
@@ -105,7 +105,7 @@ class MigrationsIT extends TestBase {
 			.build(), driver);
 
 		assertThatExceptionOfType(MigrationsException.class).isThrownBy(failingMigrations::apply)
-			.withMessage("Unexpected migration at index 0: 001 (\"FirstMigration\")");
+			.withMessage("Unexpected migration at index 0: 001 (\"FirstMigration\").");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #421