### PR TITLE
feat: Make `file:./neo4j/migrations` the default for `--location` in the CLI.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
@@ -56,12 +56,17 @@ public final class Defaults {
 	static final List<String> PACKAGES_TO_SCAN = Collections.emptyList();
 
 	/**
-	 * Default locations to scan.
+	 * Default package or folder name for locations to scan, agnostic to classpath or filesystem.
 	 */
-	public static final String LOCATIONS_TO_SCAN_VALUE = "classpath:neo4j/migrations";
+	public static final String LOCATIONS_TO_SCAN_WITHOUT_PREFIX = "neo4j/migrations";
 
 	/**
-	 * Default locations to scan.
+	 * Default locations to scan (with a {@link ac.simons.neo4j.migrations.core.internal.Location.LocationType} prefix).
+	 */
+	public static final String LOCATIONS_TO_SCAN_VALUE = "classpath:" + LOCATIONS_TO_SCAN_WITHOUT_PREFIX;
+
+	/**
+	 * Default locations to scan (with a {@link ac.simons.neo4j.migrations.core.internal.Location.LocationType} prefix).
 	 */
 	public static final List<String> LOCATIONS_TO_SCAN = Collections.singletonList(LOCATIONS_TO_SCAN_VALUE);
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/Location.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/Location.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 public final class Location {
 
 	/**
-	 * A location type.
+	 * A location type. If no prefix is given, we assume {@literal classpath:}.
 	 */
 	public enum LocationType {
 

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsProperties.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsProperties.java
@@ -49,7 +49,7 @@ public class MigrationsProperties {
 	/**
 	 * Locations of migrations scripts.
 	 */
-	private String[] locationsToScan = Defaults.LOCATIONS_TO_SCAN.toArray(new String[0]);
+	private String[] locationsToScan = new String[] { Defaults.LOCATIONS_TO_SCAN_VALUE };
 
 	/**
 	 * The transaction mode in use (Defaults to "per migration", meaning one script is run in one transaction).


### PR DESCRIPTION
When no other locations or packages are given, use `file:./neo4j/migrations` as a default to look for migrations in the CLI.

Closes #413.