### PR TITLE
feat: Add unique constraint for migration nodes on Neo4j 4.4.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.driver.Session;
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.Neo4jException;
+
+/**
+ * Some utilities to deal with Neo4j quirks. Stay away, here be dragons.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Guns n' Roses - Appetite For Democracy 3D
+ * @since 1.4.0
+ */
+final class HBD {
+
+	private static final Set<String> CODES_FOR_EXISTING_CONSTRAINT
+		= Collections.unmodifiableSet(new HashSet<>(
+		Arrays.asList("Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists",
+			"Neo.ClientError.Schema.ConstraintAlreadyExists")));
+
+	private static final String CONSTRAINT_WITH_NAME_ALREADY_EXISTS_CODE = "Neo.ClientError.Schema.ConstraintWithNameAlreadyExists";
+
+	static boolean is4xSeries(ConnectionDetails connectionDetails) {
+		return connectionDetails.getServerVersion() != null && connectionDetails.getServerVersion()
+			.replaceFirst("(?i)^Neo4j/", "").matches("^4\\.?.*");
+	}
+
+	static boolean is44OrHigher(ConnectionDetails connectionDetails) {
+
+		if (connectionDetails.getServerVersion() == null) {
+			return false;
+		}
+		String bare = connectionDetails.getServerVersion().replaceFirst("(?i)^Neo4j/", "");
+		Matcher matcher = Pattern.compile("(\\d+)\\.(\\d+).*").matcher(bare);
+		if (!matcher.matches()) {
+			return false;
+		}
+		Integer major = Integer.valueOf(matcher.group(1));
+		Integer minor = Integer.valueOf(matcher.group(2));
+		return major > 4 || (major >= 4 && minor >= 4);
+	}
+
+	static Integer silentCreateConstraint(ConnectionDetails connectionDetails, Session session, String statement,
+		String name, Supplier<String> failureMessage) {
+
+		String finalStatement;
+		String replacement = "";
+		if (is4xSeries(connectionDetails) && name != null && !name.trim().isEmpty()) {
+			replacement = name.trim() + " ";
+		}
+		finalStatement = statement.replace("$name ", replacement);
+
+		try {
+			return session.writeTransaction(tx -> tx.run(finalStatement).consume().counters().constraintsAdded());
+		} catch (Neo4jException e) {
+
+			if (!CODES_FOR_EXISTING_CONSTRAINT.contains(e.code())) {
+				throw new MigrationsException(failureMessage.get(), e);
+			}
+		}
+
+		return 0;
+	}
+
+	static Integer silentDropConstraint(ConnectionDetails connectionDetails, Session session, String statement,
+		String name) {
+
+		String finalStatement;
+		if (is4xSeries(connectionDetails) && name != null && !name.trim().isEmpty()) {
+			finalStatement = "DROP CONSTRAINT " + name.trim();
+		} else {
+			finalStatement = statement;
+		}
+
+		try {
+			return session.writeTransaction(tx ->
+				tx.run(finalStatement).consume().counters().constraintsRemoved());
+		} catch (Neo4jException e) {
+			if (!"Neo.DatabaseError.Schema.ConstraintDropFailed".equals(e.code())) {
+				throw new MigrationsException("Could not remove locks", e);
+			}
+		}
+
+		return 0;
+	}
+
+	static boolean constraintWithNameAlreadyExists(MigrationsException e) {
+		return e != null && e.getCause() instanceof ClientException && CONSTRAINT_WITH_NAME_ALREADY_EXISTS_CODE.equals(
+			((ClientException) e.getCause()).code());
+	}
+}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
@@ -20,8 +20,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.ClientException;
@@ -54,13 +52,22 @@ final class HBD {
 			return false;
 		}
 		String bare = connectionDetails.getServerVersion().replaceFirst("(?i)^Neo4j/", "");
-		Matcher matcher = Pattern.compile("(\\d+)\\.(\\d+).*").matcher(bare);
-		if (!matcher.matches()) {
+		String[] values = bare.split("\\.");
+		if (values.length < 2) {
 			return false;
 		}
-		Integer major = Integer.valueOf(matcher.group(1));
-		Integer minor = Integer.valueOf(matcher.group(2));
+
+		Integer major = valueOf(values[0]);
+		Integer minor = valueOf(values[1]);
 		return major > 4 || (major >= 4 && minor >= 4);
+	}
+
+	static Integer valueOf(String value) {
+		try {
+			return Integer.valueOf(value);
+		} catch (NumberFormatException e) {
+			return -1;
+		}
 	}
 
 	static Integer silentCreateConstraint(ConnectionDetails connectionDetails, Session session, String statement,

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
@@ -118,4 +118,7 @@ final class HBD {
 		return e != null && e.getCause() instanceof ClientException && CONSTRAINT_WITH_NAME_ALREADY_EXISTS_CODE.equals(
 			((ClientException) e.getCause()).code());
 	}
+
+	private HBD() {
+	}
 }

--- a/neo4j-migrations-core/src/main/resources/ac/simons/neo4j/migrations/core/messages.properties
+++ b/neo4j-migrations-core/src/main/resources/ac/simons/neo4j/migrations/core/messages.properties
@@ -4,3 +4,4 @@ validation-result.outcome.incomplete_migrations = Some versions previously appli
 validation-result.outcome.different_content = Versions resolved locally mismatch in either names, types or checksums compared to {0}.
 validation.database_is_invalid = Database is not in a valid state. To fix this, apply this configuration.
 validation.database_needs_repair = Database is not in a valid state and needs manual repair.
+lock_failed = Could not ensure uniqueness of __Neo4jMigrationsLock. Please make sure your instance is in a clean state, no more than 1 lock should be there simultaneously!

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ConstraintsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ConstraintsIT.java
@@ -62,7 +62,7 @@ class ConstraintsIT {
 	@ParameterizedTest
 	@CsvSource(value = { "Neo4j/3.5, false", "Neo4j/4.0, false", "neo4J/4.0, false", "Neo4j/4, false",
 		"Neo4j/4.4, true",
-		"4.5, true", "5.0, true", "5, false", "4.2, false", "N/A, false" }, nullValues = "N/A")
+		"4.5, true", "5.0, true", "5, false", "4.2, false",  "4.4.2, true", "N/A, false" }, nullValues = "N/A")
 	void shouldDetect44OrHigher(String v, boolean expected) {
 
 		ConnectionDetails cd = new DefaultConnectionDetails(null, v, null, null, null);

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ConstraintsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ConstraintsIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.assertj.core.data.Index;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Logging;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.summary.SummaryCounters;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Guns n' Roses - Appetite For Democracy 3D
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConstraintsIT {
+
+	@ParameterizedTest
+	@CsvSource(value = { "Neo4j/3.5, false", "Neo4j/4.0, true", "neo4J/4.0, true", "Neo4j/4, true", "Neo4j/4.4, true",
+		"4.2, true", "N/A, false" }, nullValues = "N/A")
+	void shouldDetectCorrectVersion(String v, boolean expected) {
+
+		ConnectionDetails cd = new DefaultConnectionDetails(null, v, null, null, null);
+		assertThat(HBD.is4xSeries(cd)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = { "Neo4j/3.5, false", "Neo4j/4.0, false", "neo4J/4.0, false", "Neo4j/4, false",
+		"Neo4j/4.4, true",
+		"4.5, true", "5.0, true", "5, false", "4.2, false", "N/A, false" }, nullValues = "N/A")
+	void shouldDetect44OrHigher(String v, boolean expected) {
+
+		ConnectionDetails cd = new DefaultConnectionDetails(null, v, null, null, null);
+		assertThat(HBD.is44OrHigher(cd)).isEqualTo(expected);
+	}
+
+	void dropAllConstraints(Driver driver) {
+
+		try (Session session = driver.session()) {
+			session.run("call db.constraints()")
+				.list(record -> "DROP " + record.get("description").asString())
+				.forEach(session::run);
+		}
+	}
+
+	static boolean is35(String tag) {
+		return "neo4j:3.5".equals(tag);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neo4j:3.5", "neo4j:4.0", "neo4j:4.4" })
+	void shouldCreateConstraints(String tag) {
+
+		final String s0 = "CREATE CONSTRAINT $name ON ( book:Book ) ASSERT book.isbn IS UNIQUE";
+		final String s1 = "CREATE CONSTRAINT ON ( person:Person ) ASSERT person.name IS UNIQUE";
+		final String s2 = "CREATE CONSTRAINT ON ( movie:Movie ) ASSERT movie.title IS UNIQUE";
+
+		Neo4jContainer<?> neo4j = getNeo4j(tag);
+
+		Config config = Config.builder().withLogging(Logging.none()).build();
+		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+			AuthTokens.basic("neo4j", neo4j.getAdminPassword()), config)) {
+
+			MigrationsConfig migrationsConfig = MigrationsConfig.defaultConfig();
+			MigrationContext ctx = new DefaultMigrationContext(migrationsConfig, driver);
+
+			Supplier<String> errorMessage = () -> "oops";
+			ConnectionDetails cd = ctx.getConnectionDetails();
+			try (Session session = ctx.getSession()) {
+				assertThat(HBD.silentCreateConstraint(cd, session, s0, "AAA", errorMessage)).isOne();
+				assertThat(HBD.silentCreateConstraint(cd, session, s1, "BBB", errorMessage)).isOne();
+				assertThat(HBD.silentCreateConstraint(cd, session, s2, null, errorMessage)).isOne();
+			}
+
+			boolean is35 = is35(tag);
+			String[] descriptions = Stream.of(s0, s1, s2).map(s -> {
+					String result = s
+						.replace("CREATE ", "")
+						.replace("$name ", "");
+					return is35 ? result : result.replaceAll("ASSERT (.+\\..+) IS", "ASSERT ($1) IS");
+				}
+			).toArray(String[]::new);
+			try (Session session = ctx.getSession()) {
+				List<Record> result = session.run("call db.constraints()").list(Function.identity());
+
+				assertThat(result.stream().map(r -> r.get("description").asString()))
+					.containsExactlyInAnyOrder(descriptions);
+
+				Stream<String> names = result.stream().map(r -> r.get("name").asString(null));
+				if (is35) {
+					assertThat(names).allMatch(Objects::isNull);
+				} else {
+					Consumer<String> isRandomConstraintName = s -> assertThat(s).startsWith("constraint_");
+					assertThat(names)
+						.hasSize(3)
+						.satisfies(s -> assertThat(s).isEqualTo("AAA"), Index.atIndex(0))
+						.satisfies(isRandomConstraintName, Index.atIndex(1));
+				}
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neo4j:3.5", "neo4j:4.0", "neo4j:4.4" })
+	void shouldDropConstraints(String tag) {
+
+		final String s0 = "CREATE CONSTRAINT $name ON ( book:Book ) ASSERT book.isbn IS UNIQUE";
+
+		Neo4jContainer<?> neo4j = getNeo4j(tag);
+
+		Config config = Config.builder().withLogging(Logging.none()).build();
+		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+			AuthTokens.basic("neo4j", neo4j.getAdminPassword()), config)) {
+
+			MigrationsConfig migrationsConfig = MigrationsConfig.defaultConfig();
+			MigrationContext ctx = new DefaultMigrationContext(migrationsConfig, driver);
+
+			Supplier<String> errorMessage = () -> "oops";
+			ConnectionDetails cd = ctx.getConnectionDetails();
+
+			try (Session session = ctx.getSession()) {
+				assertThat(HBD.silentCreateConstraint(cd, session, s0, "AAA", errorMessage)).isOne();
+			}
+
+			int dropped;
+			try (Session session = ctx.getSession()) {
+				if (is35(tag)) {
+					dropped = HBD.silentDropConstraint(cd, session,
+						"DROP CONSTRAINT ON ( n:Book ) ASSERT n.isbn IS UNIQUE", "AAA");
+				} else {
+					dropped = HBD.silentDropConstraint(cd, session, "messed up statement on purpose", "AAA");
+				}
+			}
+			assertThat(dropped).isOne();
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neo4j:4.3", "neo4j:4.4" })
+	void shouldThrowExceptionWhenConstraintsWithSameNameExists(String tag) {
+
+		Neo4jContainer<?> neo4j = getNeo4j(tag);
+
+		Config config = Config.builder().withLogging(Logging.none()).build();
+		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+			AuthTokens.basic("neo4j", neo4j.getAdminPassword()), config)) {
+
+			MigrationsConfig migrationsConfig = MigrationsConfig.defaultConfig();
+			MigrationContext ctx = new DefaultMigrationContext(migrationsConfig, driver);
+
+			Supplier<String> errorMessage = () -> "oops";
+			ConnectionDetails cd = ctx.getConnectionDetails();
+			try (Session session = ctx.getSession()) {
+
+				int created = session.run("CREATE CONSTRAINT X ON (book:Book) ASSERT book.isbn IS UNIQUE").consume()
+					.counters().constraintsAdded();
+				assertThat(created).isOne();
+
+				assertThatExceptionOfType(MigrationsException.class)
+					.isThrownBy(() -> HBD.silentCreateConstraint(cd, session,
+						"CREATE CONSTRAINT X ON (n:SomethingElse) ASSERT n.whatever IS UNIQUE", null, errorMessage))
+					.matches(HBD::constraintWithNameAlreadyExists);
+			}
+		}
+	}
+
+	SummaryCounters executeAndConsume(Session session, String statement) {
+		return session.run(statement).consume().counters();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neo4j:4.3", "neo4j:4.4", "neo4j:4.4-enterprise" })
+	void shouldPreventDuplicateVersionsWithTarget(String tag) {
+
+		Neo4jContainer<?> neo4j = getNeo4j(tag);
+
+		Config config = Config.builder().withLogging(Logging.none()).build();
+		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+			AuthTokens.basic("neo4j", neo4j.getAdminPassword()), config)) {
+
+			MigrationsConfig migrationsConfig = MigrationsConfig.defaultConfig();
+
+			Migrations migrations = new Migrations(migrationsConfig, driver);
+			migrations.clean(true);
+			migrations.apply();
+
+			try (Session session = new DefaultMigrationContext(migrationsConfig, driver).getSchemaSession()) {
+
+				session.run("CREATE (:__Neo4jMigration {version: '1', migrationTarget: 'x'})");
+				if ("neo4j:4.3".equals(tag)) {
+					assertThat(executeAndConsume(session, "CREATE (:__Neo4jMigration {version: '1', migrationTarget: 'x'})").nodesCreated()).isOne();
+
+					CleanResult result = migrations.clean(false);
+					assertThat(result.getConstraintsRemoved()).isZero();
+
+					result = migrations.clean(true);
+					assertThat(result.getConstraintsRemoved()).isEqualTo(2L);
+				} else {
+					assertThatExceptionOfType(ClientException.class)
+						.isThrownBy(() -> executeAndConsume(session, "CREATE (:__Neo4jMigration {version: '1', migrationTarget: 'x'})"))
+						.withMessageEndingWith("already exists with label `__Neo4jMigration` and properties `version` = '1', `migrationTarget` = 'x'");
+
+					CleanResult result = migrations.clean(false);
+					assertThat(result.getConstraintsRemoved()).isZero();
+
+					result = migrations.clean(true);
+					assertThat(result.getConstraintsRemoved()).isEqualTo(3L);
+				}
+			}
+		}
+	}
+
+	private Neo4jContainer<?> getNeo4j(String tag) {
+		Neo4jContainer<?> neo4j = new Neo4jContainer<>(tag)
+			.withReuse(true)
+			.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+			.withLabel("ac.simons.neo4j.migrations.core", "HBDIT");
+		neo4j.start();
+		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+			AuthTokens.basic("neo4j", neo4j.getAdminPassword()))) {
+			dropAllConstraints(driver);
+		}
+		return neo4j;
+	}
+}


### PR DESCRIPTION
This is somewhat a semi-helpful feature: It will reliable assure the uniqueness of (version,migrationTarget) for nodes with the label `__Neo4jMigration`, but we can’t guarantee the same for nodes with only the version (that is, nodes that will be created or have been created without a target database.

This is because composite indexes in Neo4j ignore null and therefor non-existent properties.

While as of today there is no way to create duplicate versions with neo4j-migration itself, a unique key should prevent external tempering.

All workarounds like having a secondary constraint with an indicator whether the optional property is present like this

```
CREATE CONSTRAINT unique_version___Neo4jMigration FOR (m:__Neo4jMigration) REQUIRE (m.version, m.migrationTarget) IS UNIQUE"
CREATE CONSTRAINT unique_version___Neo4jMigration_secondary FOR (m:__Neo4jMigration) REQUIRE (m.version, m.hasMigrationTarget) IS UNIQUE"
```

can be easily circumvented by just using Cypher or a non-conformant other tool. Therefor, we don’t do this workaround.

This closes #414.

take note @marianozunino