### PR TITLE
refactor: Separate migrations and CLI logging into syserr and sysout.

### DIFF
--- a/bin/test_native_cli.java
+++ b/bin/test_native_cli.java
@@ -49,12 +49,12 @@ public class test_native_cli {
 			"--password", neo4j.getAdminPassword(),
 			"--location", scripts,
 			"apply"
-		).start();
+		).redirectErrorStream(true).start();
 
 		p.onExit().thenAccept(done -> {
 			try (var in = new BufferedReader(new InputStreamReader(done.getInputStream()))) {
 				var output = in.lines().collect(Collectors.toCollection(LinkedHashSet::new));
-				assertThat(output).containsExactlyElementsOf(expectedOutput);
+				assertThat(output).allSatisfy(c -> expectedOutput.stream().anyMatch(c::contains));
 			} catch (IOException e) {
 				throw new UncheckedIOException(e);
 			}

--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -157,6 +157,11 @@ TIP: `neo4j-migrations` looks in the current working directory for a properties 
      Use `neo4j-migrations init` to create a file with the default values. Any options passed to `neo4j-migrations` before
      the init command will also be store.
 
+=== Output
+
+Direct information coming from the CLI itself will always go to standard out. Information coming from core migrations
+will be locked with a timestamp on standard error. This allows for controlled redirection of different information.
+
 === Safe passwords in CI/CD usage
 
 There are 4 ways to specify the password:
@@ -222,7 +227,7 @@ Database: neo4j
 | 023.1   | NichtsIstWieEsScheintNeu    | JAVA   |              |    |                | PENDING | a.s.n.m.c.t.changeset2.V023_1__NichtsIstWieEsScheintNeu      |
 | 023.1.1 | NichtsIstWieEsScheintNeuNeu | JAVA   |              |    |                | PENDING | a.s.n.m.c.t.changeset2.V023_1_1__NichtsIstWieEsScheintNeuNeu |
 | 030     | Something based on a script | CYPHER |              |    |                | PENDING | V030__Something_based_on_a_script.cypher                     |
-| 042     | The truth                   | CYPHER |              |    |                | PENDING | V042__The truth.cypher                                       |
+| 042     | The truth                   | CYPHER |              |    |                | PENDING | V042__The_truth.cypher                                       |
 +---------+-----------------------------+--------+--------------+----+----------------+---------+--------------------------------------------------------------+
 ----
 
@@ -236,13 +241,13 @@ Use `migrate` to apply migrations:
   --package ac.simons.neo4j.migrations.core.test_migrations.changeset1 \
   --package ac.simons.neo4j.migrations.core.test_migrations.changeset2 \
   migrate
-Applied migration 001 ("FirstMigration")
-Applied migration 002 ("AnotherMigration")
-Applied migration 023 ("NichtsIstWieEsScheint")
-Applied migration 023.1 ("NichtsIstWieEsScheintNeu")
-Applied migration 023.1.1 ("NichtsIstWieEsScheintNeuNeu")
-Applied migration 030 ("Something based on a script")
-Applied migration 042 ("The truth")
+[2022-05-31T11:25:29.894372000] Applied migration 001 ("FirstMigration").
+[2022-05-31T11:25:29.985192000] Applied migration 002 ("AnotherMigration").
+[2022-05-31T11:25:30.001006000] Applied migration 023 ("NichtsIstWieEsScheint").
+[2022-05-31T11:25:30.016117000] Applied migration 023.1 ("NichtsIstWieEsScheintNeu").
+[2022-05-31T11:25:30.032421000] Applied migration 023.1.1 ("NichtsIstWieEsScheintNeuNeu").
+[2022-05-31T11:25:30.056182000] Applied migration 030 ("Something based on a script").
+[2022-05-31T11:25:30.077719000] Applied migration 042 ("The truth").
 Database migrated to version 042.
 ----
 
@@ -280,13 +285,13 @@ Another `migrate` - this time with all packages - gives us the following output 
   --package ac.simons.neo4j.migrations.core.test_migrations.changeset1 \
   --package ac.simons.neo4j.migrations.core.test_migrations.changeset2 \
   migrate
-Skipping already applied migration 001 ("FirstMigration")
-Skipping already applied migration 002 ("AnotherMigration")
-Skipping already applied migration 023 ("NichtsIstWieEsScheint")
-Skipping already applied migration 023.1 ("NichtsIstWieEsScheintNeu")
-Skipping already applied migration 023.1.1 ("NichtsIstWieEsScheintNeuNeu")
-Skipping already applied migration 030 ("Something based on a script")
-Skipping already applied migration 042 ("The truth")
+[2022-05-31T11:26:23.054169000] Skipping already applied migration 001 ("FirstMigration")
+[2022-05-31T11:26:23.058779000] Skipping already applied migration 002 ("AnotherMigration")
+[2022-05-31T11:26:23.059185000] Skipping already applied migration 023 ("NichtsIstWieEsScheint")
+[2022-05-31T11:26:23.059504000] Skipping already applied migration 023.1 ("NichtsIstWieEsScheintNeu")
+[2022-05-31T11:26:23.059793000] Skipping already applied migration 023.1.1 ("NichtsIstWieEsScheintNeuNeu")
+[2022-05-31T11:26:23.060068000] Skipping already applied migration 030 ("Something based on a script")
+[2022-05-31T11:26:23.060329000] Skipping already applied migration 042 ("The truth")
 Database migrated to version 042.
 ----
 

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateCommand.java
@@ -45,8 +45,11 @@ final class MigrateCommand extends ConnectedCommand {
 	Integer withMigrations(Migrations migrations) {
 
 		Optional<MigrationVersion> lastAppliedMigration = migrations.apply();
-		lastAppliedMigration.map(MigrationVersion::getValue)
-			.ifPresent(version -> MigrationsCli.LOGGER.log(Level.INFO, "Database migrated to version {0}.", version));
+		if (lastAppliedMigration.isPresent()) {
+			MigrationsCli.LOGGER.log(Level.INFO, "Database migrated to version {0}.", lastAppliedMigration.get().getValue());
+		} else {
+			MigrationsCli.LOGGER.log(Level.INFO, "No migrations have been applied.");
+		}
 		return 0;
 	}
 }

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/internal/MigrationsCliConsoleFormatter.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/internal/MigrationsCliConsoleFormatter.java
@@ -26,7 +26,7 @@ import java.util.logging.LogRecord;
  */
 public final class MigrationsCliConsoleFormatter extends Formatter {
 	@Override
-	public String format(LogRecord record) {
-		return formatMessage(record) + System.lineSeparator();
+	public String format(LogRecord logRecord) {
+		return formatMessage(logRecord) + System.lineSeparator();
 	}
 }

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/internal/MigrationsCliConsoleFormatter.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/internal/MigrationsCliConsoleFormatter.java
@@ -15,33 +15,18 @@
  */
 package ac.simons.neo4j.migrations.cli.internal;
 
+import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
-import java.util.logging.StreamHandler;
 
 /**
- * Always log to stdout. Not for external use outside this program.
+ * This formatter just returns the formatted message and doesn't react to any formatting.
  *
- * @author Michael J. Simons
- * @since 0.0.5
+ * @author Micahel J. Simons
+ * @since TBA
  */
-public final class MigrationsCliConsoleHandler extends StreamHandler {
-
-	/**
-	 * Creates a new handler with a fixed pointer to {@link System#out}.
-	 */
-	@SuppressWarnings("squid:S106") // Using System.out is the point of this exercise.
-	public MigrationsCliConsoleHandler() {
-		setOutputStream(System.out);
-	}
-
+public final class MigrationsCliConsoleFormatter extends Formatter {
 	@Override
-	public synchronized void publish(LogRecord logRecord) {
-		super.publish(logRecord);
-		flush();
-	}
-
-	@Override
-	public synchronized void close() {
-		flush();
+	public String format(LogRecord record) {
+		return formatMessage(record) + System.lineSeparator();
 	}
 }

--- a/neo4j-migrations-cli/src/main/resources/META-INF/native-image/eu.michael-simons.neo4j/neo4j-migrations-cli/reflection-config.json
+++ b/neo4j-migrations-cli/src/main/resources/META-INF/native-image/eu.michael-simons.neo4j/neo4j-migrations-cli/reflection-config.json
@@ -7,5 +7,14 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "name": "ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleFormatter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
   }
 ]

--- a/neo4j-migrations-cli/src/main/resources/logging.properties
+++ b/neo4j-migrations-cli/src/main/resources/logging.properties
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers=ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler
+handlers=java.util.logging.ConsoleHandler
 .level = INFO
-java.util.logging.SimpleFormatter.format = %5$s%n
+java.util.logging.SimpleFormatter.format = [%1$tFT%1$tk:%1$tM:%1$tS.%1$tN] %5$s%n
+
+ac.simons.neo4j.migrations.cli.MigrationsCli.handlers = ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler
+ac.simons.neo4j.migrations.cli.MigrationsCli.level = INFO
+ac.simons.neo4j.migrations.cli.MigrationsCli.useParentHandlers = false
 
 ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler.level = INFO
-ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler.formatter = java.util.logging.SimpleFormatter
+ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler.formatter = ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleFormatter

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateCommandTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateCommandTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ac.simons.neo4j.migrations.core.MigrationVersion;
 import ac.simons.neo4j.migrations.core.Migrations;
 
 import java.util.Optional;
@@ -33,18 +34,29 @@ import org.junit.jupiter.api.Test;
 class MigrateCommandTest {
 
 	@Test
-	void shouldIndicateNoMigrations() throws Exception {
+	void shouldGiveInformationAboutMigrations() throws Exception {
 
+		// Done in one test, because otherwise tapping sysout goes upside down. No mood to bother too long with this as of writing.
 		String result = tapSystemOut(() -> {
+
+			Migrations noMigrations = mock(Migrations.class);
+			when(noMigrations.apply()).thenReturn(Optional.empty());
+
 			Migrations migrations = mock(Migrations.class);
-			when(migrations.apply()).thenReturn(Optional.empty());
+			MigrationVersion version = mock(MigrationVersion.class);
+			when(version.getValue()).thenReturn("4711");
+			when(migrations.apply()).thenReturn(Optional.of(version));
 
 			MigrateCommand cmd = new MigrateCommand();
-
+			cmd.withMigrations(noMigrations);
 			cmd.withMigrations(migrations);
 			System.out.flush();
+
+			verify(noMigrations).apply();
 			verify(migrations).apply();
 		});
-		assertThat(result).isEqualTo("No migrations have been applied." + System.lineSeparator());
+		assertThat(result).isEqualTo(
+			"No migrations have been applied." + System.lineSeparator() + "Database migrated to version 4711."
+			+ System.lineSeparator());
 	}
 }

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateCommandTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateCommandTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class MigrateCommandTest {
+
+	@Test
+	void shouldIndicateNoMigrations() throws Exception {
+
+		String result = tapSystemOut(() -> {
+			Migrations migrations = mock(Migrations.class);
+			when(migrations.apply()).thenReturn(Optional.empty());
+
+			MigrateCommand cmd = new MigrateCommand();
+
+			cmd.withMigrations(migrations);
+			System.out.flush();
+			verify(migrations).apply();
+		});
+		assertThat(result).isEqualTo("No migrations have been applied." + System.lineSeparator());
+	}
+}

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
@@ -294,7 +294,7 @@ class MigrationsCliTest {
 		}
 
 		@Test
-		void shouldUseEnvFirst() throws Exception {
+		void shouldUseEnvFirst() {
 
 			MigrationsCli cli = new MigrationsCli();
 			setUserName(cli);


### PR DESCRIPTION
This allows for proper distinguising CLI and Migrations (core) output.

This change alone requires a minor version bump to indicate its potentially breaking nature.
