### PR TITLE
fix: Check if dbms.procedures is available or not.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jCodes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jCodes.java
@@ -43,6 +43,16 @@ final class Neo4jCodes {
 	 */
 	static final String CONSTRAINT_ALREADY_EXISTS = "Neo.ClientError.Schema.ConstraintAlreadyExists";
 
+	/**
+	 * Used in notifications to warn about deprecated features.
+	 */
+	static final String FEATURE_DEPRECATION_WARNING = "Neo.ClientNotification.Statement.FeatureDeprecationWarning";
+
+	/**
+	 * Used when a procedure was not found.
+	 */
+	static final String PROCEDURE_NOT_FOUND = "Neo.ClientError.Procedure.ProcedureNotFound";
+
 	static final Set<String> CODES_FOR_EXISTING_CONSTRAINT = Collections.unmodifiableSet(new HashSet<>(
 		Arrays.asList(EQUIVALENT_SCHEMA_RULE_ALREADY_EXISTS, CONSTRAINT_ALREADY_EXISTS)));
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Index.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Index.java
@@ -309,6 +309,7 @@ public final class Index extends AbstractCatalogItem<Index.Type> {
 				break;
 			case "node_label_property":
 			case "BTREE":
+			case "RANGE": // One of the Neo4j 5+ future indexes.
 				type = Type.PROPERTY;
 				break;
 			case "FULLTEXT":

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultMigrationContextIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultMigrationContextIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Logging;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+/**
+ * @author Michael J. Simons
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DefaultMigrationContextIT {
+
+	@ParameterizedTest
+	@ValueSource(strings = { "neo4j:3.5", "neo4j:4.3", "neo4j:4.4" })
+	void shouldUseShowProceduresIfNecessary(String tag) {
+
+		try (Neo4jContainer<?> neo4j = getNeo4j(tag)) {
+
+			Config config = Config.builder().withLogging(Logging.none()).build();
+			try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(),
+				AuthTokens.basic("neo4j", neo4j.getAdminPassword()), config)) {
+
+				DefaultMigrationContext ctx = new DefaultMigrationContext(MigrationsConfig.defaultConfig(), driver);
+				ConnectionDetails connectionDetails = ctx.getConnectionDetails();
+				assertThat(connectionDetails.getUsername()).isEqualTo("neo4j");
+			}
+		}
+	}
+
+	private Neo4jContainer<?> getNeo4j(String tag) {
+		Neo4jContainer<?> neo4j = new Neo4jContainer<>(tag)
+			.withReuse(TestcontainersConfiguration.getInstance().environmentSupportsReuse())
+			.withLabel("ac.simons.neo4j.migrations.core", this.getClass().getSimpleName());
+		neo4j.start();
+		return neo4j;
+	}
+}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/TestBase.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/TestBase.java
@@ -89,8 +89,8 @@ abstract class TestBase {
 		List<String> indexesToBeDropped;
 		try (Session session = driver.session(sessionConfig)) {
 			session.run("MATCH (n) DETACH DELETE n");
-			constraintsToBeDropped = session.run("SHOW CONSTRAINTS YIELD 'DROP CONSTRAINT ' + name as cmd").list(r -> r.get("cmd").asString());
-			indexesToBeDropped = session.run("SHOW INDEXES YIELD 'DROP INDEX ' + name as cmd").list(r -> r.get("cmd").asString());
+			constraintsToBeDropped = session.run("SHOW CONSTRAINTS YIELD name RETURN 'DROP CONSTRAINT ' + name as cmd").list(r -> r.get("cmd").asString());
+			indexesToBeDropped = session.run("SHOW INDEXES YIELD name RETURN 'DROP INDEX ' + name as cmd").list(r -> r.get("cmd").asString());
 		}
 
 		constraintsToBeDropped.forEach(cmd -> dropConstraint(driver, database, cmd));

--- a/neo4j-migrations-core/src/test/resources/doublewillfail/44+/V0001__DoStuff.cypher
+++ b/neo4j-migrations-core/src/test/resources/doublewillfail/44+/V0001__DoStuff.cypher
@@ -1,0 +1,2 @@
+// assume that version is ge 4.4
+CREATE CONSTRAINT FOR (f:A) REQUIRE f.id IS UNIQUE;

--- a/neo4j-migrations-core/src/test/resources/doublewillfail/older/V0001__DoStuff.cypher
+++ b/neo4j-migrations-core/src/test/resources/doublewillfail/older/V0001__DoStuff.cypher
@@ -1,1 +1,2 @@
+// assume that version is lt 4.4
 CREATE CONSTRAINT ON (f:A) ASSERT f.id IS UNIQUE;


### PR DESCRIPTION
It has been deprecated in 4.4 and removed in 5.0.
To run a quick smoke test against 5.0-dev, some changes in test base has
been necessary and the `RANGE` index type needed to be added.
