### PR TITLE
fix: Use proper URIs for filesystem based locations.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,28 @@ jobs:
           name: assembly
           path: neo4j-migrations-cli/target/assembly
 
+  ensure_windows_files:
+    if:  ${{ github.event.sender.login != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: Ensure file locations working on windows
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Download assembly
+        uses: actions/download-artifact@v1
+        with:
+          name: assembly
+          path: assembly
+      - name: Print info
+        env:
+          EXTERNAL_TEST_DB_URL: ${{ secrets.EXTERNAL_TEST_DB_URL }}
+          EXTERNAL_TEST_DB_PWD: ${{ secrets.EXTERNAL_TEST_DB_PWD }}
+        run: assembly/bin/neo4j-migrations.bat -a %EXTERNAL_TEST_DB_URL% --password:env EXTERNAL_TEST_DB_PWD --location file:///$pwd/neo4j-migrations-test-resources/src/main/resources/some/changeset info mode=LOCAL
+
   ensure_jdk_compat:
     name: Ensure compatibilty with minimum required Java version
     runs-on: ubuntu-latest

--- a/bin/test_native_cli.java
+++ b/bin/test_native_cli.java
@@ -27,8 +27,8 @@ public class test_native_cli {
 	public static void main(String... a) throws Exception {
 
 		var executable = Paths.get("./neo4j-migrations-cli/target/neo4j-migrations").toAbsolutePath().normalize().toString();
-		var location1 = "file://" + Paths.get("./neo4j-migrations-test-resources/src/main/resources/some/changeset").toAbsolutePath().normalize();
-		var location2 = "file://" + Paths.get("./neo4j-migrations-test-resources/src/main/resources/catalogbased_changesets").toAbsolutePath().normalize();
+		var location1 = Paths.get("./neo4j-migrations-test-resources/src/main/resources/some/changeset").toAbsolutePath().normalize().toUri().toString();
+		var location2 = Paths.get("./neo4j-migrations-test-resources/src/main/resources/catalogbased_changesets").toAbsolutePath().normalize().toUri().toString();
 
 		// Let Ryuk take care of it, so no try/catch with autoclose
 		var neo4j = new Neo4jContainer<>("neo4j:4.3").withReuse(true);

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -268,7 +268,7 @@ public final class MigrationsCli implements Runnable {
 		if (!Files.isDirectory(defaultPath)) {
 			return new String[0];
 		}
-		String defaultLocationToScan = LocationType.FILESYSTEM.getPrefix() + "://" + defaultPath.toString().replace('\\', '/');
+		String defaultLocationToScan = defaultPath.toUri().toString();
 		LOGGER.log(Level.FINE, "Neither locations nor packages to scan configured, using {0}.", defaultLocationToScan);
 		return new String[] { defaultLocationToScan };
 	}

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
@@ -251,8 +251,7 @@ class MigrationsCliTest {
 			Path newDir = Files.createDirectories(defaultPath);
 			try {
 				MigrationsConfig config = cli.getConfig();
-				assertThat(config.getLocationsToScan()).containsExactly(
-					"file://" + Paths.get("neo4j/migrations").toAbsolutePath());
+				assertThat(config.getLocationsToScan()).containsExactly(defaultPath.toUri().toString());
 			} finally {
 				if (!defaultPath.equals(newDir)) {
 					deltree(newDir);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Location.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Location.java
@@ -15,6 +15,7 @@
  */
 package ac.simons.neo4j.migrations.core;
 
+import java.net.URI;
 import java.util.Locale;
 
 /**
@@ -53,21 +54,21 @@ public final class Location {
 
 	/**
 	 * Creates a new {@link Location} object from a given location that has an optional prefix (protocol) and a name
-	 * @param prefixAndName A name with an optional prefix
+	 * @param uri A name with an optional scheme / name
 	 * @return A location object
 	 */
-	public static Location of(String prefixAndName) {
+	public static Location of(String uri) {
 		// Yep, Regex would work, too. I know how to do this with regex, but it's slower and not necessary.
-		int indexOfFirstColon = prefixAndName.indexOf(":");
+		int indexOfFirstColon = uri.indexOf(":");
 		if (indexOfFirstColon < 0) {
-			return new Location(LocationType.CLASSPATH, prefixAndName);
+			return new Location(LocationType.CLASSPATH, uri);
 		}
-		if (prefixAndName.length() < 3) {
-			throw new MigrationsException("Invalid resource name: '" + prefixAndName + "'");
+		if (uri.length() < 3) {
+			throw new MigrationsException("Invalid resource name: '" + uri + "'");
 		}
 
-		String prefix = prefixAndName.substring(0, indexOfFirstColon).toLowerCase(Locale.ENGLISH).trim();
-		String name = prefixAndName.substring(indexOfFirstColon + 1).trim();
+		String prefix = uri.substring(0, indexOfFirstColon).toLowerCase(Locale.ENGLISH).trim();
+		String name = uri.substring(indexOfFirstColon + 1).trim();
 
 		if (name.length() == 0) {
 			throw new MigrationsException("Invalid name.");
@@ -79,7 +80,7 @@ public final class Location {
 		} else if (LocationType.FILESYSTEM.getPrefix().equals(prefix)) {
 			type = LocationType.FILESYSTEM;
 		} else {
-			throw new MigrationsException(("Invalid resource prefix: '" + prefix + "'"));
+			throw new MigrationsException("Invalid resource prefix: '" + prefix + "'");
 		}
 
 		return new Location(type, name);
@@ -105,5 +106,9 @@ public final class Location {
 	 */
 	public String getName() {
 		return name;
+	}
+
+	URI toUri() {
+		return URI.create(type.getPrefix() + ":" + name.replace('\\', '/'));
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
@@ -18,6 +18,7 @@ package ac.simons.neo4j.migrations.core;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
@@ -100,7 +101,7 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 		List<T> listOfMigrations = new ArrayList<>();
 
 		List<String> classpathLocations = new ArrayList<>();
-		List<String> filesystemLocations = new ArrayList<>();
+		List<URI> filesystemLocations = new ArrayList<>();
 
 		for (String prefixAndLocation : config.getLocationsToScan()) {
 
@@ -108,7 +109,7 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 			if (location.getType() == Location.LocationType.CLASSPATH) {
 				classpathLocations.add(location.getName());
 			} else if (location.getType() == Location.LocationType.FILESYSTEM) {
-				filesystemLocations.add(location.getName());
+				filesystemLocations.add(location.toUri());
 			}
 		}
 
@@ -134,7 +135,7 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 			.collect(Collectors.toList());
 	}
 
-	private List<T> scanFilesystemLocations(List<String> filesystemLocations, MigrationsConfig config) {
+	private List<T> scanFilesystemLocations(List<URI> filesystemLocations, MigrationsConfig config) {
 
 		if (filesystemLocations.isEmpty()) {
 			return Collections.emptyList();
@@ -144,7 +145,7 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 
 		List<T> resources = new ArrayList<>();
 
-		for (String location : filesystemLocations) {
+		for (URI location : filesystemLocations) {
 			Path path = Paths.get(location);
 			if (!Files.isDirectory(path)) {
 				continue;


### PR DESCRIPTION
Using the `name` of a location without the proper scheme will lead to invalid characters in the path under Windows systems.

Fixes #521.
