### PR TITLE
fix: Add a check for Neo4j 5 constraint backing indexes.

### DIFF
--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationIT.java
@@ -153,7 +153,12 @@ class CatalogBasedMigrationIT {
 	}
 
 	private Neo4jContainer<?> getNeo4j(Neo4jVersion version, boolean enterprise, boolean createDefaultConstraints) throws IOException {
-		Neo4jContainer<?> neo4j = new Neo4jContainer<>(String.format("neo4j:%s" + (enterprise ? "-enterprise" : ""), version.toString()))
+		return getNeo4j(version, null, enterprise, createDefaultConstraints);
+	}
+
+	private Neo4jContainer<?> getNeo4j(Neo4jVersion version, String versionValue, boolean enterprise, boolean createDefaultConstraints) throws IOException {
+		String theVersion = versionValue == null ? version.toString() : versionValue;
+		Neo4jContainer<?> neo4j = new Neo4jContainer<>(String.format("neo4j:%s" + (enterprise ? "-enterprise" : ""), theVersion))
 			.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
 			.withReuse(version.hasIdempotentOperations() && TestcontainersConfiguration.getInstance()
 				.environmentSupportsReuse())

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
@@ -62,7 +62,7 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 			this.enterprise = enterprise;
 		}
 	}
-	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = Collections.unmodifiableList(Arrays.asList("3.5", "4.1", "4.2", "4.3", "4.4"));
+	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = Collections.unmodifiableList(Arrays.asList("3.5", "4.1", "4.2", "4.3", "4.4", "LATEST"));
 	private static final List<String> SUPPORTED_VERSIONS_ENTERPRISE = Collections.singletonList("4.4");
 
 	@Override

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/catalog/IndexTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/catalog/IndexTest.java
@@ -234,7 +234,7 @@ class IndexTest {
 	}
 
 	@Test
-	void shouldParseConstraintIndex() {
+	void shouldParseConstraintBackingIndexes() {
 		Value indexName = Values.value("index_name");
 		Value type = Values.value("BTREE");
 		Value uniqueness = Values.value("UNIQUE");
@@ -246,6 +246,30 @@ class IndexTest {
 				new AbstractMap.SimpleEntry<>("name", indexName),
 				new AbstractMap.SimpleEntry<>("type", type),
 				new AbstractMap.SimpleEntry<>("uniqueness", uniqueness),
+				new AbstractMap.SimpleEntry<>("entityType", Values.value("NODE")),
+				new AbstractMap.SimpleEntry<>("labelsOrTypes", tokenNames),
+				new AbstractMap.SimpleEntry<>("properties", properties))));
+
+		assertThat(index.getType()).isEqualTo(Index.Type.CONSTRAINT_BACKING_INDEX);
+		assertThat(index.getTargetEntityType()).isEqualTo(TargetEntityType.NODE);
+		assertThat(index.getName().getValue()).isEqualTo("index_name");
+		assertThat(index.getIdentifier()).isEqualTo("[label1]");
+		assertThat(index.getDeconstructedIdentifiers()).containsExactly("label1");
+		assertThat(index.getProperties()).containsExactlyInAnyOrder("property1", "property2");
+	}
+
+	@Test
+	void shouldParseConstraintBackingIndexesNeo5j() {
+		Value indexName = Values.value("index_name");
+		Value type = Values.value("BTREE");
+		Value tokenNames = Values.value(Collections.singletonList("label1"));
+		Value properties = Values.value(Arrays.asList("property1", "property2"));
+
+		Index index = Index.parse(
+			new MapAccessorAndRecordImpl(makeMap(
+				new AbstractMap.SimpleEntry<>("name", indexName),
+				new AbstractMap.SimpleEntry<>("type", type),
+				new AbstractMap.SimpleEntry<>("owningConstraint", Values.value("constraint_name")),
 				new AbstractMap.SimpleEntry<>("entityType", Values.value("NODE")),
 				new AbstractMap.SimpleEntry<>("labelsOrTypes", tokenNames),
 				new AbstractMap.SimpleEntry<>("properties", properties))));

--- a/neo4j-migrations-core/src/test/resources/constraints/Create_LATEST_test_constraints.cypher
+++ b/neo4j-migrations-core/src/test/resources/constraints/Create_LATEST_test_constraints.cypher
@@ -1,0 +1,6 @@
+CREATE CONSTRAINT constraint_name1 FOR (n:Person) REQUIRE (n.firstname, n.surname) IS NODE KEY;
+CREATE CONSTRAINT constraint_name3 FOR (n:Book) REQUIRE n.isbn IS NOT NULL;
+CREATE CONSTRAINT constraint_name4 FOR ()-[r:LIKED]-() REQUIRE r.day IS NOT NULL;
+CREATE CONSTRAINT constraint_name5 FOR (n:Book) REQUIRE n.isbn IS UNIQUE;
+CREATE CONSTRAINT constraint_name6 FOR ()-[l:LIKED]-() REQUIRE l.`x,liked.y` IS NOT NULL;
+CREATE CONSTRAINT reconsidering_my_life_choices1 FOR (n:Person) REQUIRE (n.firstname, n.surname, n.`person.whatever`, n.`person.a,person.b 😱`) IS NODE KEY;


### PR DESCRIPTION
This also adds the possibility to run LATEST in test with some manual editing as long as there is no public available Neo4j 5 image.

Closes #561.
