### PR TITLE
refactor: Avoid an unlock attempt if the lock isn’t locked.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -372,7 +372,9 @@ public final class Migrations {
 			}
 		} finally {
 			try {
-				lock.unlock();
+				if (lock.isLocked()) {
+					lock.unlock();
+				}
 			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, "Could not unlock… Please check for residues (Nodes labeled `__Neo4jMigrationsLock`).");
 			}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsLockIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsLockIT.java
@@ -38,6 +38,7 @@ class MigrationsLockIT extends TestBase {
 		MigrationsLock lock = new MigrationsLock(context);
 		String lockId = lock.lock();
 
+		assertThat(lock.isLocked()).isTrue();
 		try (Session session = context.getSession()) {
 
 			long cnt = session.run("MATCH (l:__Neo4jMigrationsLock {id: $id}) RETURN count(l) AS cnt",
@@ -48,6 +49,8 @@ class MigrationsLockIT extends TestBase {
 
 			lock.unlock();
 		}
+
+		assertThat(lock.isLocked()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
See #572. In cases in which something prevented the aquisiation of a lock at all, there’s no chance it can be safely unlocked anway.
