### PR TITLE
feat: Add `:USE` command.

### DIFF
--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -121,6 +121,24 @@ MigrationsConfig configLookingAtDifferentPlaces = MigrationsConfig.builder()
 
 ==== Switching database inside Cypher scripts
 
+===== With the command `:USE`
+
+The command `:USE` has the same meaning as in Neo4j-Browser or Cypher-Shell: All following commands will be applied in the given database.
+The transaction mode will be applied as configured per database and will "restart" when you switch the database again.
+This is the preferred way of doing things like this:
+
+.Switching databases in flight with `:USE`
+[source,cypher]
+----
+CREATE database foo IF NOT EXISTS WAIT;
+:use foo;
+CREATE (n:InFoo {foo: 'bar'});
+:use neo4j;
+CREATE (n:InNeo4j);
+----
+
+===== With the Cypher keyword `USE`
+
 It is of course possible to use the Cypher keyword `USE <graph>` (See https://neo4j.com/docs/cypher-manual/current/clauses/use/[USE]) inside your scripts.
 There are a couple of things to remember, though:
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResource.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResource.java
@@ -100,7 +100,12 @@ public interface CypherResource {
 	String getChecksum();
 
 	/**
-	 * @return A list of executable statements (they might have or might not have comments in them, we don't care)
+	 * Returns all statements that are not single line comments. The list of statements might contain {@code :use database}
+	 * statements, which neo4j-migrations (browser and cypher-shell) can deal with but the pure driver can't.
+	 * <p>
+	 * The returned list will never include single line comments, but the statements themselves might contain comments.
+	 *
+	 * @return A list of executable statements
 	 */
 	List<String> getExecutableStatements();
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
@@ -23,12 +23,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
@@ -59,6 +63,18 @@ final class DefaultCypherResource implements CypherResource {
 			}
 			return false;
 		};
+
+
+	private static final String USE_DATABASE_EXPRESSION =
+		"(?i):use +([a-z][a-z\\d.\\-]{2,62})(?:;?(?:" + Strings.LINE_DELIMITER + ")?)?";
+
+	/**
+	 * Cypher delimiter
+	 */
+	private static final String CYPHER_STATEMENT_DELIMITER = ";(?:" + Strings.LINE_DELIMITER + ")";
+
+	private static final Pattern USE_DATABASE_PATTERN = Pattern.compile(USE_DATABASE_EXPRESSION);
+
 
 	/**
 	 * The identifier of this resource.
@@ -156,7 +172,7 @@ final class DefaultCypherResource implements CypherResource {
 
 		List<String> newStatements = new ArrayList<>();
 		try (Scanner scanner = new Scanner(inputStreamSupplier.get(), Defaults.CYPHER_SCRIPT_ENCODING.name())
-			.useDelimiter(Defaults.CYPHER_STATEMENT_DELIMITER)) {
+			.useDelimiter(CYPHER_STATEMENT_DELIMITER)) {
 			while (scanner.hasNext()) {
 				String statement = scanner.next().trim().replaceAll(";$", "").trim();
 				if (this.autocrlf) {
@@ -165,16 +181,35 @@ final class DefaultCypherResource implements CypherResource {
 				if (statement.isEmpty()) {
 					continue;
 				}
-				newStatements.add(statement);
+				Matcher useMatcher = USE_DATABASE_PATTERN.matcher(statement);
+				boolean isMl = statement.contains("\n");
+				StringBuilder finalStatement = new StringBuilder();
+				if (useMatcher.find()) {
+					handleUseStatement(newStatements, useMatcher, finalStatement);
+				}
+				while (useMatcher.find()) {
+					if (isMl) {
+						useMatcher.appendTail(finalStatement);
+						throw new MigrationsException(
+							"Can't switch database inside a statement, offending statement:\n" + finalStatement);
+					}
+					handleUseStatement(newStatements, useMatcher, finalStatement);
+				}
+				useMatcher.appendTail(finalStatement);
+				if (!finalStatement.isEmpty()) {
+					newStatements.add(finalStatement.toString());
+				}
 			}
 		}
 
 		return Collections.unmodifiableList(newStatements);
 	}
 
-	/**
-	 * @return A list of executable statements (they might have or might not have comments in them, we don't care)
-	 */
+	private static void handleUseStatement(List<String> newStatements, Matcher useMatcher, StringBuilder finalStatement) {
+		useMatcher.appendReplacement(finalStatement, "");
+		newStatements.add(useMatcher.group(0).trim());
+	}
+
 	@Override
 	public List<String> getExecutableStatements() {
 		return getStatements(NOT_A_SINGLE_COMMENT);
@@ -208,43 +243,112 @@ final class DefaultCypherResource implements CypherResource {
 		return builder.build();
 	}
 
-	static void executeIn(CypherResource cypherResource, MigrationContext context, UnaryOperator<SessionConfig.Builder> sessionCustomizer) {
+	static Optional<String> getDatabaseName(String line) {
 
-		try (Session session = context.getDriver().session(context.getSessionConfig(sessionCustomizer))) {
-
-			List<String> executableStatements = cypherResource.getExecutableStatements();
-
-			int numberOfStatements = 0;
-			MigrationsConfig.TransactionMode transactionMode = context.getConfig().getTransactionMode();
-			if (transactionMode == MigrationsConfig.TransactionMode.PER_MIGRATION) {
-
-				LOGGER.log(Level.FINE, "Executing statements in script \"{0}\" in one transaction",
-					cypherResource.getIdentifier());
-				numberOfStatements = session.writeTransaction(t -> {
-					int cnt = 0;
-					for (String statement : executableStatements) {
-						run(t, statement);
-						++cnt;
-					}
-					return cnt;
-				});
-
-			} else if (transactionMode == MigrationsConfig.TransactionMode.PER_STATEMENT) {
-
-				LOGGER.log(Level.FINE, "Executing statements contained in script \"{0}\" in separate transactions",
-					cypherResource.getIdentifier());
-				for (String statement : executableStatements) {
-					numberOfStatements += session.writeTransaction(t -> {
-						run(t, statement);
-						return 1;
-					});
-				}
-			} else {
-				throw new MigrationsException("Unknown transaction mode " + transactionMode);
-			}
-
-			LOGGER.log(Level.FINE, "Executed {0} statements", numberOfStatements);
+		Matcher matcher = USE_DATABASE_PATTERN.matcher(line);
+		if (matcher.matches()) {
+			return Optional.of(matcher.group(1).toLowerCase(Locale.ROOT));
 		}
+		return Optional.empty();
+	}
+
+	static void executeIn(CypherResource cypherResource, MigrationContext context,
+		UnaryOperator<SessionConfig.Builder> sessionCustomizer) {
+
+		List<DatabaseAndStatements> statementsByDatabase = groupStatements(cypherResource.getExecutableStatements());
+
+		statementsByDatabase.forEach(databaseAndStatements -> {
+
+			UnaryOperator<SessionConfig.Builder> finalSessionCustomizer =
+				databaseAndStatements.database()
+					.map(database -> (UnaryOperator<SessionConfig.Builder>) builder -> builder.withDatabase(database))
+					.orElse(sessionCustomizer);
+
+			try (Session session = context.getDriver().session(context.getSessionConfig(finalSessionCustomizer))) {
+
+				List<String> executableStatements = databaseAndStatements.statements();
+
+				int numberOfStatements = 0;
+				MigrationsConfig.TransactionMode transactionMode = context.getConfig().getTransactionMode();
+				if (transactionMode == MigrationsConfig.TransactionMode.PER_MIGRATION) {
+
+					LOGGER.log(Level.FINE, "Executing statements in script \"{0}\" in one transaction",
+						cypherResource.getIdentifier());
+					numberOfStatements = session.writeTransaction(t -> {
+						int cnt = 0;
+						for (String statement : executableStatements) {
+							run(t, statement);
+							++cnt;
+						}
+						return cnt;
+					});
+
+				} else if (transactionMode == MigrationsConfig.TransactionMode.PER_STATEMENT) {
+
+					LOGGER.log(Level.FINE, "Executing statements contained in script \"{0}\" in separate transactions",
+						cypherResource.getIdentifier());
+					for (String statement : executableStatements) {
+						numberOfStatements += session.writeTransaction(t -> {
+							run(t, statement);
+							return 1;
+						});
+					}
+				} else {
+					throw new MigrationsException("Unknown transaction mode " + transactionMode);
+				}
+
+				LOGGER.log(Level.FINE, "Executed {0} statements", numberOfStatements);
+			}
+		});
+	}
+
+	/**
+	 * A record holding together a list of statements and the database in which they should be executed.
+	 */
+	static class DatabaseAndStatements {
+
+		private final Optional<String> database;
+
+		private final List<String> statements;
+
+		DatabaseAndStatements(Optional<String> database, List<String> statements) {
+			this.database = database;
+			this.statements = Collections.unmodifiableList(statements);
+		}
+
+		public Optional<String> database() {
+			return database;
+		}
+
+		public List<String> statements() {
+			return statements;
+		}
+	}
+
+	/**
+	 * Groups statements into a consecutive lists, each entry starting with a new database. Groups are not in the sense
+	 * of a GROUP BY as they are not distinct.
+	 *
+	 * @param statements The list of statements to group, containing use statements
+	 * @return An ordered grouped list, with groups not necessary unique
+	 */
+	static List<DatabaseAndStatements> groupStatements(List<String> statements) {
+
+		List<DatabaseAndStatements> result = new ArrayList<>();
+		Optional<String> current = Optional.empty();
+		List<String> sublist = new ArrayList<>();
+		for (String statement : statements) {
+			Optional<String> databaseName = getDatabaseName(statement);
+			if (databaseName.isPresent()) { // If empty, it is not a :use statement
+				result.add(new DatabaseAndStatements(current, sublist));
+				current = databaseName;
+				sublist = new ArrayList<>();
+				continue;
+			}
+			sublist.add(statement);
+		}
+		result.add(new DatabaseAndStatements(current, sublist));
+		return result;
 	}
 
 	static void run(QueryRunner runner, String statement) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
@@ -16,7 +16,6 @@
 package ac.simons.neo4j.migrations.core;
 
 import ac.simons.neo4j.migrations.core.MigrationsConfig.TransactionMode;
-import ac.simons.neo4j.migrations.core.internal.Strings;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -45,11 +44,6 @@ public final class Defaults {
 	 * Default encoding for Cypher scripts.
 	 */
 	public static final Charset CYPHER_SCRIPT_ENCODING = StandardCharsets.UTF_8;
-
-	/**
-	 * Cypher delimiter
-	 */
-	static final String CYPHER_STATEMENT_DELIMITER = ";(:?" + Strings.LINE_DELIMITER + ")";
 
 	/**
 	 * Default packages to scan.

--- a/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/CypherResource.java
+++ b/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/CypherResource.java
@@ -95,17 +95,22 @@ public sealed interface CypherResource permits DefaultCypherResource {
 	String getIdentifier();
 
 	/**
-	 * @return The checksum of this resource
+	 * {@return The checksum of this resource}
 	 */
 	String getChecksum();
 
 	/**
-	 * @return A list of executable statements (they might have or might not have comments in them, we don't care)
+	 * Returns all statements that are not single line comments. The list of statements might contain {@code :use database}
+	 * statements, which neo4j-migrations (browser and cypher-shell) can deal with but the pure driver can't.
+	 * <p>
+	 * The returned list will never include single line comments, but the statements themselves might contain comments.
+	 *
+	 * @return A list of executable statements
 	 */
 	List<String> getExecutableStatements();
 
 	/**
-	 * @return A list of surely identifiable single line comments, either "standalone" or before a valid cypher statement
+	 * {@return A list of surely identifiable single line comments, either "standalone" or before a valid cypher statement}
 	 */
 	List<String> getSingleLineComments();
 }

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsEEIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsEEIT.java
@@ -138,6 +138,32 @@ class MigrationsEEIT {
 	}
 
 	@Test
+	void useShouldWork() {
+
+		TestBase.clearDatabase(driver, "neo4j");
+
+		Migrations migrations;
+		migrations = new Migrations(MigrationsConfig.builder()
+			.withLocationsToScan("classpath:usestatements")
+			.build(), driver);
+		migrations.apply();
+
+		try (Session session = driver.session()) {
+
+			long cnt = session.run("MATCH (n:`InNeo4j`) RETURN count(n) AS cnt").single().get("cnt").asLong();
+			assertThat(cnt).isEqualTo(1L);
+
+			cnt = session.run("MATCH (n:`InFoo`) RETURN count(n) AS cnt").single().get("cnt").asLong();
+			assertThat(cnt).isZero();
+
+			cnt = session.run("SHOW databases YIELD name WHERE name = \"foo\" RETURN count(distinct name) AS cnt").single().get("cnt").asLong();
+			assertThat(cnt).isZero();
+		}
+
+		assertThat(TestBase.lengthOfMigrations(driver, null)).isEqualTo(2);
+	}
+
+	@Test
 	void needsSchemaDatabase() {
 
 		TestBase.clearDatabase(driver, "neo4j");

--- a/neo4j-migrations-core/src/test/resources/parsing/with_use_statements.cypher
+++ b/neo4j-migrations-core/src/test/resources/parsing/with_use_statements.cypher
@@ -1,0 +1,9 @@
+MATCH (n) RETURN count(n);
+CREATE (f) RETURN f;
+:use system
+CALL apoc.trigger.add('test', "CALL apoc.log.info('OK') RETURN 1", { phase: 'after' });
+:use neo4j
+MATCH (n)
+DETACH DELETE n;
+:use system;
+CALL apoc.trigger.remove('testTrigger');

--- a/neo4j-migrations-core/src/test/resources/parsing/with_use_statements_wrong.cypher
+++ b/neo4j-migrations-core/src/test/resources/parsing/with_use_statements_wrong.cypher
@@ -1,0 +1,10 @@
+MATCH (n) RETURN count(n);
+CREATE (f) RETURN f;
+:use system
+CALL apoc.trigger.add('test', "CALL apoc.log.info('OK') RETURN 1", { phase: 'after' });
+:use neo4j
+MATCH (n)
+:use something
+DETACH DELETE n;
+:use system;
+CALL apoc.trigger.remove('testTrigger');

--- a/neo4j-migrations-core/src/test/resources/usestatements/V0001__Create_and_use_database.cypher
+++ b/neo4j-migrations-core/src/test/resources/usestatements/V0001__Create_and_use_database.cypher
@@ -1,0 +1,5 @@
+CREATE database foo IF NOT EXISTS WAIT;
+:use foo;
+CREATE (n:InFoo {foo: 'bar'});
+:use neo4j;
+CREATE (n:InNeo4j);

--- a/neo4j-migrations-core/src/test/resources/usestatements/V0002__Drop_foo.cypher
+++ b/neo4j-migrations-core/src/test/resources/usestatements/V0002__Drop_foo.cypher
@@ -1,0 +1,1 @@
+DROP database foo WAIT;


### PR DESCRIPTION
This allows switching databases in migrations, analogue to browser and cypher-shell and closes #559.
