### PR TITLE
refactor: Deprecate `ac.simons.neo4j.migrations.core.Migration#getDescription`.

### DIFF
--- a/extensions/neo4j-migrations-formats-adoc/pom.xml
+++ b/extensions/neo4j-migrations-formats-adoc/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cli</artifactId>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations</artifactId>
@@ -132,6 +132,15 @@
 					</newVersion>
 					<parameter>
 						<breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+						<overrideCompatibilityChangeParameters>
+							<overrideCompatibilityChangeParameter>
+								<!-- See https://github.com/siom79/japicmp/issues/201 -->
+								<compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+								<binaryCompatible>true</binaryCompatible>
+								<sourceCompatible>true</sourceCompatible>
+								<semanticVersionLevel>MINOR</semanticVersionLevel>
+							</overrideCompatibilityChangeParameter>
+						</overrideCompatibilityChangeParameters>
 						<excludes>
 							<!--
 							 | Those are public classes in a package private interface which cannot be accessed from outside my own package.

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
@@ -30,13 +30,17 @@ import java.util.function.UnaryOperator;
 public abstract class AbstractCypherBasedMigration implements Migration {
 
 	protected final CypherResource cypherResource;
+	/**
+	 * @deprecated since 1.9.0, see {@link #getOptionalDescription()}
+	 */
+	@Deprecated
 	protected final String description;
 	protected final MigrationVersion version;
 
 	protected AbstractCypherBasedMigration(CypherResource cypherResource) {
 		this.cypherResource = cypherResource;
 		this.version = MigrationVersion.parse(this.cypherResource.getIdentifier());
-		this.description = this.version.getDescription();
+		this.description = this.version.getOptionalDescription().orElse(null);
 	}
 
 	@Override
@@ -45,8 +49,14 @@ public abstract class AbstractCypherBasedMigration implements Migration {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public final String getDescription() {
-		return description;
+		return version.getOptionalDescription().orElse(null);
+	}
+
+	@Override
+	public Optional<String> getOptionalDescription() {
+		return version.getOptionalDescription();
 	}
 
 	/**

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
@@ -37,6 +37,7 @@ public abstract class AbstractCypherBasedMigration implements Migration {
 	protected final String description;
 	protected final MigrationVersion version;
 
+	@SuppressWarnings("squid:S1874") // Assignment to description
 	protected AbstractCypherBasedMigration(CypherResource cypherResource) {
 		this.cypherResource = cypherResource;
 		this.version = MigrationVersion.parse(this.cypherResource.getIdentifier());

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
@@ -353,9 +353,15 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 		return version;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public String getDescription() {
-		return version.getDescription();
+		return version.getOptionalDescription().orElse(null);
+	}
+
+	@Override
+	public Optional<String> getOptionalDescription() {
+		return version.getOptionalDescription();
 	}
 
 	@Override

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -276,7 +276,7 @@ final class ChainBuilder {
 		static Element pendingElement(Migration pendingMigration) {
 			return new DefaultChainElement(MigrationState.PENDING, Migrations.getMigrationType(pendingMigration),
 				pendingMigration.getChecksum().orElse(null), pendingMigration.getVersion().getValue(),
-				pendingMigration.getDescription(), pendingMigration.getSource(), null);
+				pendingMigration.getOptionalDescription().orElse(null), pendingMigration.getSource(), null);
 		}
 
 		private final MigrationState state;
@@ -325,8 +325,14 @@ final class ChainBuilder {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public String getDescription() {
 			return description;
+		}
+
+		@Override
+		public Optional<String> getOptionalDescription() {
+			return Optional.ofNullable(description);
 		}
 
 		@Override

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
@@ -15,8 +15,6 @@
  */
 package ac.simons.neo4j.migrations.core;
 
-import java.util.Optional;
-
 /**
  * Interface to be implemented for Java-based migrations.
  *
@@ -31,8 +29,9 @@ public interface JavaBasedMigration extends Migration {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	default String getDescription() {
-		return Optional.ofNullable(getVersion().getDescription()).orElseGet(() -> getClass().getSimpleName());
+		return getVersion().getOptionalDescription().orElseGet(() -> getClass().getSimpleName());
 	}
 
 	@Override

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
@@ -32,8 +32,18 @@ public interface Migration {
 
 	/**
 	 * @return Some description.
+	 * @deprecated Since 1.9.0 see {@link #getOptionalDescription()}
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	String getDescription();
+
+	/**
+	 * @return An optional description of this migration.
+	 */
+	default Optional<String> getOptionalDescription() {
+		return Optional.ofNullable(getDescription());
+	}
 
 	/**
 	 * @return Something that describes the source of this migration.

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
@@ -41,6 +41,7 @@ public interface Migration {
 	/**
 	 * @return An optional description of this migration.
 	 */
+	@SuppressWarnings("squid:S1874")
 	default Optional<String> getOptionalDescription() {
 		return Optional.ofNullable(getDescription());
 	}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChain.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChain.java
@@ -95,7 +95,7 @@ public interface MigrationChain extends ConnectionDetails {
 
 	/**
 	 * @return The database if applicable (Neo4j 4.0 and up), maybe null
-	 * @deprecated since 1.1.0, please use {@link #getOptionalDatabaseName()} ()}
+	 * @deprecated since 1.1.0, see {@link #getOptionalDatabaseName()}
 	 */
 	@Deprecated
 	String getDatabaseName();
@@ -138,8 +138,19 @@ public interface MigrationChain extends ConnectionDetails {
 
 		/**
 		 * @return The description of the migration.
+		 * @deprecated Since 1.9.0 see {@link #getOptionalDescription()}
 		 */
+		@SuppressWarnings("DeprecatedIsStillUsed")
+		@Deprecated
 		String getDescription();
+
+		/**
+		 * @return An optional description of the migration represented by this element.
+		 * @since 1.9.0
+		 */
+		default Optional<String> getOptionalDescription() {
+			return Optional.ofNullable(getDescription());
+		}
 
 		/**
 		 * @return The name of the script or class on which this migration is based.

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChain.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChain.java
@@ -148,6 +148,7 @@ public interface MigrationChain extends ConnectionDetails {
 		 * @return An optional description of the migration represented by this element.
 		 * @since 1.9.0
 		 */
+		@SuppressWarnings("squid:S1874")
 		default Optional<String> getOptionalDescription() {
 			return Optional.ofNullable(getDescription());
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChainFormat.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationChainFormat.java
@@ -86,7 +86,7 @@ final class MigrationChainFormat {
 			column.add(element.getVersion());
 
 			column = table.computeIfAbsent("Description", k -> new ArrayList<>());
-			column.add(element.getDescription());
+			column.add(element.getOptionalDescription().orElse(""));
 
 			column = table.computeIfAbsent("Type", k -> new ArrayList<>());
 			column.add(element.getType().name());

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
@@ -17,6 +17,7 @@ package ac.simons.neo4j.migrations.core;
 
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,8 +91,8 @@ public final class MigrationVersion {
 	/**
 	 * @return The extracted description. Maybe null.
 	 */
-	String getDescription() {
-		return description;
+	Optional<String> getOptionalDescription() {
+		return Optional.ofNullable(description);
 	}
 
 	@Override

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -530,10 +530,10 @@ public final class Migrations {
 		Map<String, Object> properties = new HashMap<>();
 
 		properties.put(PROPERTY_MIGRATION_VERSION, migration.getVersion().getValue());
-		properties.put(PROPERTY_MIGRATION_DESCRIPTION, migration.getDescription());
+		migration.getOptionalDescription().ifPresent(v -> properties.put(PROPERTY_MIGRATION_DESCRIPTION, v));
 		properties.put("type", getMigrationType(migration).name());
 		properties.put("source", migration.getSource());
-		migration.getChecksum().ifPresent(checksum -> properties.put("checksum", checksum));
+		migration.getChecksum().ifPresent(v -> properties.put("checksum", v));
 
 		return Collections.unmodifiableMap(properties);
 	}
@@ -562,6 +562,7 @@ public final class Migrations {
 
 	static String toString(Migration migration) {
 
-		return String.format("%s (\"%s\")", migration.getVersion(), migration.getDescription());
+		return migration.getVersion().getValue()
+			+ migration.getOptionalDescription().map(d -> String.format(" (\"%s\")", d)).orElse("");
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
@@ -141,7 +141,7 @@ public final class MigrationsConfig {
 
 	/**
 	 * @return An optional target database, maybe {@literal null}
-	 * @deprecated since 1.1.0, please use {@link #getOptionalDatabase()}
+	 * @deprecated since 1.1.0, see {@link #getOptionalDatabase()}
 	 */
 	@Deprecated
 	public String getDatabase() {
@@ -166,7 +166,7 @@ public final class MigrationsConfig {
 
 	/**
 	 * @return An optional user to impersonate, maybe {@literal null}
-	 * @deprecated since 1.1.0, please use {@link #getOptionalImpersonatedUser()}
+	 * @deprecated since 1.1.0, see {@link #getOptionalImpersonatedUser()}
 	 */
 	@Deprecated
 	public String getImpersonatedUser() {
@@ -183,7 +183,7 @@ public final class MigrationsConfig {
 
 	/**
 	 * @return Optional user information about the user executing the migration, maybe {@literal null}
-	 * @deprecated since 1.1.0, please use {@link #getOptionalInstalledBy()}
+	 * @deprecated since 1.1.0, see {@link #getOptionalInstalledBy()}
 	 */
 	@Deprecated
 	public String getInstalledBy() {
@@ -258,7 +258,7 @@ public final class MigrationsConfig {
 	/**
 	 * This is internal API and will be made package private in 2.0.0
 	 * @return True if there are packages to scan
-	 * @deprecated Since 1.1.0, will be removed from public without replace.
+	 * @deprecated Since 1.1.0, will be removed from public without replacement.
 	 */
 	@SuppressWarnings("DeprecatedIsStillUsed")
 	@Deprecated

--- a/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/Migration.java
+++ b/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/Migration.java
@@ -32,8 +32,18 @@ public sealed interface Migration permits AbstractCypherBasedMigration, Migratio
 
 	/**
 	 * {@return some description}
+	 * @deprecated Since 1.9.0 see {@link #getOptionalDescription()}
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	String getDescription();
+
+	/**
+	 * {@return An optional description of this migration}
+	 */
+	default Optional<String> getOptionalDescription() {
+		return Optional.ofNullable(getDescription());
+	}
 
 	/**
 	 * {@return something that describes the source of this migration}

--- a/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/Migration.java
+++ b/neo4j-migrations-core/src/main/java17/ac/simons/neo4j/migrations/core/Migration.java
@@ -41,6 +41,7 @@ public sealed interface Migration permits AbstractCypherBasedMigration, Migratio
 	/**
 	 * {@return An optional description of this migration}
 	 */
+	@SuppressWarnings("squid:S1874")
 	default Optional<String> getOptionalDescription() {
 		return Optional.ofNullable(getDescription());
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationTest.java
@@ -101,6 +101,17 @@ class CatalogBasedMigrationTest {
 			.allMatch(p -> p instanceof EditionPrecondition || p instanceof QueryPrecondition);
 	}
 
+	@SuppressWarnings("deprecation")
+	@Test
+	void shouldParseDescription() {
+
+		URL url = Objects.requireNonNull(CatalogBasedMigration.class.getResource("/catalogbased/identical-migrations/V01__01.xml"));
+
+		Migration migration = CatalogBasedMigration.from(url);
+		assertThat(migration.getDescription()).isEqualTo("01");
+		assertThat(migration.getOptionalDescription()).hasValue("01");
+	}
+
 	@Test
 	void shouldParsePreconditions2() {
 		URL url = CatalogBasedMigration.class.getResource("/preconditions/V0002__Create_node_keys.xml");

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
@@ -203,6 +203,16 @@ class DefaultCypherResourceTest {
 	}
 
 	@Test
+	void shouldParseDescription() {
+
+		URL url = DefaultCypherResourceTest.class.getResource("/parsing/V01__without_assumption.cypher");
+
+		Migration migration = new CypherBasedMigration(url);
+		assertThat(migration.getDescription()).isEqualTo("without assumption");
+		assertThat(migration.getOptionalDescription()).hasValue("without assumption");
+	}
+
+	@Test
 	void randomCommentsMustChangeChecksums() {
 
 		URL script1 = DefaultCypherResourceTest.class.getResource("/parsing/V01__with_random_comments.cypher");

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
@@ -202,6 +202,7 @@ class DefaultCypherResourceTest {
 		assertThat(migrationWithAssumptions.getAlternativeChecksums()).contains("1995107586");
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void shouldParseDescription() {
 

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DiscovererTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DiscovererTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Nested;
@@ -45,8 +46,11 @@ class DiscovererTest {
 					"ac.simons.neo4j.migrations.core.test_migrations.changeset1").build(), Mockito.mock(Driver.class));
 
 			Collection<JavaBasedMigration> migrations = new JavaBasedMigrationDiscoverer().discover(context);
-			assertThat(migrations).hasSize(2)
-				.extracting(Migration::getDescription)
+			assertThat(migrations)
+				.extracting(Migration::getOptionalDescription)
+				.filteredOn(Optional::isPresent)
+				.hasSize(2)
+				.extracting(Optional::get)
 				.contains("FirstMigration", "AnotherMigration");
 		}
 
@@ -58,8 +62,11 @@ class DiscovererTest {
 					"ac.simons.neo4j.migrations.core.test_migrations.changeset3").build(), Mockito.mock(Driver.class));
 
 			Collection<JavaBasedMigration> migrations = new JavaBasedMigrationDiscoverer().discover(context);
-			assertThat(migrations).hasSize(1)
-				.extracting(Migration::getDescription)
+			assertThat(migrations)
+				.extracting(Migration::getOptionalDescription)
+				.filteredOn(Optional::isPresent)
+				.hasSize(1)
+				.extracting(Optional::get)
 				.contains("InnerMigration");
 		}
 	}
@@ -82,8 +89,11 @@ class DiscovererTest {
 					"classpath:my/awesome/migrations", "classpath:some/changeset").build(), Mockito.mock(Driver.class));
 
 			Collection<Migration> migrations = ResourceDiscoverer.forMigrations(new DefaultClasspathResourceScanner()).discover(context);
-			assertThat(migrations).hasSize(12)
-				.extracting(Migration::getDescription)
+			assertThat(migrations)
+				.extracting(Migration::getOptionalDescription)
+				.filteredOn(Optional::isPresent)
+				.hasSize(12)
+				.extracting(Optional::get)
 				.contains("delete old data", "create new data",
 					"BondTheNameIsBond",
 					"BondTheNameIsBondNew",
@@ -123,8 +133,11 @@ class DiscovererTest {
 					Mockito.mock(Driver.class));
 
 				Collection<Migration> migrations = ResourceDiscoverer.forMigrations(new DefaultClasspathResourceScanner()).discover(context);
-				assertThat(migrations).hasSize(3)
-					.extracting(Migration::getDescription)
+				assertThat(migrations)
+					.extracting(Migration::getOptionalDescription)
+					.filteredOn(Optional::isPresent)
+					.hasSize(3)
+					.extracting(Optional::get)
 					.contains("One", "Two", "Three");
 			} finally {
 				for (File file : files) {

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DiscoveryServiceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DiscoveryServiceTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -45,8 +46,11 @@ class DiscoveryServiceTest {
 			.build(), Mockito.mock(Driver.class));
 
 		List<Migration> migrations = new DiscoveryService().findMigrations(context);
-		assertThat(migrations).hasSize(16)
-			.extracting(Migration::getDescription)
+		assertThat(migrations)
+			.extracting(Migration::getOptionalDescription)
+			.filteredOn(Optional::isPresent)
+			.hasSize(16)
+			.map(Optional::get)
 			.containsExactly("FirstMigration", "AnotherMigration", "InnerMigration", "BondTheNameIsBond",
 				"BondTheNameIsBondNew", "BondTheNameIsBondNewNew", "Create constraints", "Die halbe Wahrheit", "Die halbe Wahrheit neu",
 					"Die halbe Wahrheit neu neu", "NichtsIstWieEsScheint", "NichtsIstWieEsScheintNeu", "NichtsIstWieEsScheintNeuNeu",

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationVersionTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationVersionTest.java
@@ -37,7 +37,7 @@ class MigrationVersionTest {
 		MigrationVersion migrationVersion;
 		migrationVersion = MigrationVersion.parse(name);
 		assertThat(migrationVersion.getValue()).isEqualTo(value);
-		assertThat(migrationVersion.getDescription()).isEqualTo(description);
+		assertThat(migrationVersion.getOptionalDescription()).hasValue(description);
 	}
 
 	@ParameterizedTest
@@ -48,7 +48,7 @@ class MigrationVersionTest {
 		MigrationVersion migrationVersion;
 		migrationVersion = MigrationVersion.parse(name);
 		assertThat(migrationVersion.getValue()).isEqualTo(value);
-		assertThat(migrationVersion.getDescription()).isEqualTo(description);
+		assertThat(migrationVersion.getOptionalDescription()).hasValue(description);
 	}
 
 	@Test
@@ -56,7 +56,7 @@ class MigrationVersionTest {
 
 		MigrationVersion migrationVersion;
 		migrationVersion = MigrationVersion.parse("V1__a_b");
-		assertThat(migrationVersion.getDescription()).isEqualTo("a b");
+		assertThat(migrationVersion.getOptionalDescription()).hasValue("a b");
 	}
 
 	@ParameterizedTest

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
@@ -292,7 +292,7 @@ class MigrationsIT extends TestBase {
 
 		Optional<MigrationVersion> finalVersion = migrations.apply();
 		assertThat(lengthOfMigrations(driver, null)).isEqualTo(1);
-		assertThat(finalVersion).map(MigrationVersion::getDescription).hasValue("Just a couple of matches");
+		assertThat(finalVersion).flatMap(MigrationVersion::getOptionalDescription).hasValue("Just a couple of matches");
 
 		configuration = MigrationsConfig.builder()
 			.withLocationsToScan("classpath:ml/unix")
@@ -302,7 +302,7 @@ class MigrationsIT extends TestBase {
 
 		finalVersion = migrations.apply();
 		assertThat(lengthOfMigrations(driver, null)).isEqualTo(1);
-		assertThat(finalVersion).map(MigrationVersion::getDescription).hasValue("Just a couple of matches");
+		assertThat(finalVersion).flatMap(MigrationVersion::getOptionalDescription).hasValue("Just a couple of matches");
 	}
 
 	@Test

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb-testharness</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb</artifactId>

--- a/neo4j-migrations-examples/pom.xml
+++ b/neo4j-migrations-examples/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples</artifactId>

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-maven-plugin</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/pom.xml
+++ b/neo4j-migrations-quarkus-parent/deployment/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-deployment</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/src/test/java/ac/simons/neo4j/migrations/quarkus/WithDifferentLocationIT.java
+++ b/neo4j-migrations-quarkus-parent/deployment/src/test/java/ac/simons/neo4j/migrations/quarkus/WithDifferentLocationIT.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -81,8 +82,13 @@ class WithDifferentLocationIT {
 		}
 
 		var elements = migrations.info().getElements();
-		assertThat(elements).hasSize(2).element(0)
-			.extracting(MigrationChain.Element::getDescription).isEqualTo("2nd location");
+		assertThat(elements)
+			.extracting(MigrationChain.Element::getOptionalDescription)
+			.filteredOn(Optional::isPresent)
+			.hasSize(2)
+			.element(0)
+			.extracting(Optional::get)
+			.isEqualTo("2nd location");
 	}
 
 	@AfterEach

--- a/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
+++ b/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-integration-tests</artifactId>

--- a/neo4j-migrations-quarkus-parent/integration-tests/src/main/java/ac/simons/neo4j/migrations/quarkus/it/MigrationsResource.java
+++ b/neo4j-migrations-quarkus-parent/integration-tests/src/main/java/ac/simons/neo4j/migrations/quarkus/it/MigrationsResource.java
@@ -45,7 +45,7 @@ public class MigrationsResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	public List<String> get() {
 		return migrations.info().getElements().stream()
-			.map(e -> e.getVersion() + ": " + e.getDescription() + " (" + e.getState() + ")")
+			.map(e -> e.getVersion() + ": " + e.getOptionalDescription().orElse("n/a") + " (" + e.getState() + ")")
 			.collect(Collectors.toList());
 
 	}

--- a/neo4j-migrations-quarkus-parent/pom.xml
+++ b/neo4j-migrations-quarkus-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-parent</artifactId>

--- a/neo4j-migrations-quarkus-parent/runtime/pom.xml
+++ b/neo4j-migrations-quarkus-parent/runtime/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-autoconfigure</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationIT.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationIT.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ac.simons.neo4j.migrations.core.MigrationChain;
 import ac.simons.neo4j.migrations.core.Migrations;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
@@ -63,8 +65,11 @@ class MigrationsAutoConfigurationIT {
 
 		MigrationChain migrationChain = migrations.info();
 
-		assertThat(migrationChain.getElements()).hasSize(2);
-		assertThat(migrationChain.getElements()).extracting(MigrationChain.Element::getDescription)
+		assertThat(migrationChain.getElements())
+			.extracting(MigrationChain.Element::getOptionalDescription)
+			.filteredOn(Optional::isPresent)
+			.extracting(Optional::get)
+			.hasSize(2)
 			.containsExactly("KeepMe", "SomeOtherMigration");
 
 		try (Session session = driver.session()) {

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>

--- a/neo4j-migrations-test-resources/pom.xml
+++ b/neo4j-migrations-test-resources/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-resources</artifactId>

--- a/neo4j-migrations-test-results/pom.xml
+++ b/neo4j-migrations-test-results/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>1.8.4-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-results</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>eu.michael-simons.neo4j</groupId>
 	<artifactId>neo4j-migrations-parent</artifactId>
-	<version>1.8.4-SNAPSHOT</version>
+	<version>1.9.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Neo4j Migrations</name>


### PR DESCRIPTION
The above method is deprecated for removal in 2.0 and replaced with
`getOptionalDescription()`. Similar method
`ac.simons.neo4j.migrations.core.MigrationChain.Element#getDescription`
has been deprecated as well.

This closes #310.
