### PR TITLE
fix: Improve quotation papttern.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/Strings.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/Strings.java
@@ -65,10 +65,7 @@ public final class Strings {
 
 	private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
-	private static final String BACKTICK_OR_UC = "[`\\\\\u0060]";
-
-	private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile(
-		String.format("(?<!%1$s)%1$s(?:%1$s{2})*(?!%1$s)", BACKTICK_OR_UC));
+	private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile("\\\\u0060|(?<!`)`(?:`{2})*(?!`)");
 
 	/**
 	 * A Base64 encoder.

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/internal/StringsTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/internal/StringsTest.java
@@ -97,6 +97,8 @@ final class StringsTest {
 		"Hi`````there, `Hi``````there`",
 		"`a`b`c`, ```a``b``c```",
 		"\u0060a`b`c\u0060d\u0060, ```a``b``c``d```",
+		"Foo\\`bar, `Foo\\``bar`",
+		"Foo\\\\`bar, `Foo\\\\``bar`",
 	})
 	void shouldEscapeProper(String in, String expected) {
 		String value = Strings.escapeIfNecessary(in);


### PR DESCRIPTION
* Too many escapes of the backslash
* No need to check for the actual ` and the unicode value
* BUT a need to check for the escaped unicode proper (which is literael
  \\u0060, written down as Java String becomes \\\\u0060, no further
  escapeing for the regex necessary
