### PR TITLE
refactor: Log skipped resources if they are not dedicated Cypher callbacks.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Discoverer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Discoverer.java
@@ -16,6 +16,7 @@
 package ac.simons.neo4j.migrations.core;
 
 import java.util.Collection;
+import java.util.logging.Logger;
 
 /**
  * Discoverer of migrations.
@@ -26,6 +27,11 @@ import java.util.Collection;
  * @since 0.0.3
  */
 public interface Discoverer<T> {
+
+	/**
+	 * Logger used for writing specific discovery information.
+	 */
+	Logger LOGGER = Logger.getLogger(Discoverer.class.getName());
 
 	/**
 	 * Discover migrations within the given context.

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
@@ -59,7 +59,11 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 						return path.endsWith(provider.getExtension());
 					}
 					Matcher matcher = MigrationVersion.VERSION_PATTERN.matcher(path);
-					return matcher.find() && provider.getExtension().equals(matcher.group("ext"));
+					boolean isValidResource = matcher.find();
+					if (!isValidResource && LOGGER.isLoggable(Level.FINE) && !LifecyclePhase.canParse(path)) {
+						LOGGER.log(Level.FINE, "Skipping resource {0}", path);
+					}
+					return isValidResource && provider.getExtension().equals(matcher.group("ext"));
 				} catch (UnsupportedEncodingException e) {
 					throw new MigrationsException("Somethings broken: UTF-8 encoding not supported.");
 				}

--- a/neo4j-migrations-core/src/test/resources/my/awesome/migrations/V5001_AlsoNotAMigration.cypher
+++ b/neo4j-migrations-core/src/test/resources/my/awesome/migrations/V5001_AlsoNotAMigration.cypher
@@ -1,0 +1,1 @@
+// one underscore missing


### PR DESCRIPTION
Configure `ac.simons.neo4j.migrations.core.Discoverer` to log `DEBUG` to see the messages.

Closes #672.
