### PR TITLE
build: Package the modules prior to site generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build/
 
 .DS_Store
 dependency-reduced-pom.xml
+\.*.swp

--- a/bin/generate-site.sh
+++ b/bin/generate-site.sh
@@ -7,10 +7,10 @@ DIR="$(dirname "$(realpath "$0")")"
 TARGET_FOLDER=$1
 SOURCE_BRANCH=$2
 
-cd $DIR/..
+cd "$DIR"/..
 
 # Generate the documentation
-./mvnw --no-transfer-progress asciidoctor:process-asciidoc@generate-docs -pl :neo4j-migrations-parent -Dproject.build.docs=$TARGET_FOLDER -Dproject.build.docs.branch=$SOURCE_BRANCH
+./mvnw --no-transfer-progress asciidoctor:process-asciidoc@generate-docs -pl :neo4j-migrations-parent -Dproject.build.docs="$TARGET_FOLDER" -Dproject.build.docs.branch="$SOURCE_BRANCH"
 
 # For whatever reasons maven-project-info-reports-plugin:3.1.2:dependencies goes nuts on that one
 # it's a pom project, there will be no classes, but apparently the plugin thinks different
@@ -18,10 +18,10 @@ mkdir -p neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boo
 # This fails for some weird Ruby / JRuby errors on GitHub; test results modified as they depend from the ext as well.
 sed -i.bak -e '/<module>extensions\/neo4j-migrations-formats-adoc<\/module>/d' -e '/<module>neo4j-migrations-test-results<\/module>/d' pom.xml
 # Now we can go
-./mvnw --no-transfer-progress -q compile site:site site:stage
+./mvnw --no-transfer-progress -q -Dfast -Dmaven.test.skip=true package site:site site:stage
 # Restore things
 mv pom.xml.bak pom.xml
 
 # Copy the site
-rm -rf $TARGET_FOLDER/site &&
-mv target/staging $TARGET_FOLDER/site
+rm -rf "$TARGET_FOLDER"/site &&
+mv target/staging "$TARGET_FOLDER"/site


### PR DESCRIPTION
The manifest plugin adds the automic (but deterministic) module name in the packaging phase, not in the compile phase.
Therefor, the site plugin would fail with

```
Creating an aggregated report for both named and unnamed modules is not possible.
Ensure that every module has a module descriptor or is a jar with a MANIFEST.MF containing an Automatic-Module-Name.
```

as the core module now is on the module path by default.
