### PR TITLE
feat: Allow programmatic control over repeatable Java based migrations.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractCypherBasedMigration.java
@@ -78,4 +78,9 @@ public abstract non-sealed class AbstractCypherBasedMigration implements Migrati
 	public final void apply(MigrationContext context) throws MigrationsException {
 		DefaultCypherResource.executeIn(cypherResource, context, UnaryOperator.identity());
 	}
+
+	@Override
+	public final boolean isRepeatable() {
+		return getVersion().isRepeatable();
+	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
@@ -408,6 +408,11 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 	}
 
 	@Override
+	public boolean isRepeatable() {
+		return version.isRepeatable();
+	}
+
+	@Override
 	public List<Precondition> getPreconditions() {
 		return Collections.unmodifiableList(preconditions);
 	}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -108,7 +108,7 @@ final class ChainBuilder {
 				throw new MigrationsException("Unexpected migration at index " + i + ": " + Migrations.toString(newMigration) + ".");
 			}
 
-			if (newMigration.getVersion().isRepeatable() != expectedVersion.isRepeatable()) {
+			if (newMigration.isRepeatable() != expectedVersion.isRepeatable()) {
 				throw new MigrationsException("State of " + Migrations.toString(newMigration) + " changed from " + (expectedVersion.isRepeatable() ? "repeatable to non-repeatable" : "non-repeatable to repeatable"));
 			}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
@@ -42,6 +42,21 @@ public non-sealed interface JavaBasedMigration extends Migration {
 	}
 
 	/**
+	 * Return {@literal true} to mark this Java based migration explicitly as repeatable. By default, a Java based
+	 * migration will be repeatable when it's name matches the repeatable version pattern {@literal Rxzy__Something_something.java},
+	 * it will always be repeated as the default checksum is empty.
+	 * <p>
+	 * You can take full control over this by overwriting this method and in addition, {@link #getChecksum()} and react in that
+	 * according to your needs.
+	 *
+	 * @return {@literal true} if this is a repeatable migration
+	 * @since 2.0.0
+	 */
+	default boolean isRepeatable() {
+		return getVersion().isRepeatable();
+	}
+
+	/**
 	 * Helper method for retrieving the default constructor of a given class. When such a constructor exist, it will be
 	 * made accessible.
 	 *

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migration.java
@@ -54,4 +54,10 @@ public sealed interface Migration permits AbstractCypherBasedMigration, Migratio
 	 * @throws MigrationsException In case anything happens, wrap your exception or create a new one
 	 */
 	void apply(MigrationContext context);
+
+	/**
+	 * @return {@literal true} if this migration can be safely repeated
+	 * @since 2.0.0
+	 */
+	boolean isRepeatable();
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
@@ -38,7 +38,7 @@ public final class MigrationVersion {
 	private final String description;
 	/**
 	 * A flag indicating that this version can be safely repeated, even on checksum changes.
-	 * @since TBA
+	 * @since 1.13.3
 	 */
 	private final boolean repeatable;
 
@@ -103,9 +103,9 @@ public final class MigrationVersion {
 
 	/**
 	 * @return {@literal true} if this version can be safely applied multiple times, even on checksum changes
-	 * @since TBA
+	 * @since 1.13.3
 	 */
-	public boolean isRepeatable() {
+	boolean isRepeatable() {
 		return repeatable;
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -558,12 +558,10 @@ public final class Migrations {
 
 	boolean checksumOfRepeatableChanged(MigrationChain currentChain, Migration migration) {
 
-		if (!migration.getVersion().isRepeatable()) {
+		if (!migration.isRepeatable()) {
 			return false;
 		}
-		if (migration instanceof JavaBasedMigration) {
-			return true;
-		}
+
 		Optional<String> appliedChecksum = currentChain.getElements().stream()
 			.filter(e -> e.getVersion().equals(migration.getVersion().getValue()))
 			.findFirst()
@@ -672,7 +670,7 @@ public final class Migrations {
 		properties.put(PROPERTY_MIGRATION_VERSION, migration.getVersion().getValue());
 		migration.getOptionalDescription().ifPresent(v -> properties.put(PROPERTY_MIGRATION_DESCRIPTION, v));
 		properties.put("type", getMigrationType(migration).name());
-		properties.put("repeatable", migration.getVersion().isRepeatable());
+		properties.put("repeatable", migration.isRepeatable());
 		properties.put("source", migration.getSource());
 		migration.getChecksum().ifPresent(v -> properties.put("checksum", v));
 

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset5/V003__Repeatable.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset5/V003__Repeatable.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core.test_migrations.changeset5;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.neo4j.driver.Session;
+
+import ac.simons.neo4j.migrations.core.JavaBasedMigration;
+import ac.simons.neo4j.migrations.core.MigrationContext;
+
+/**
+ * @author Michael J. Simons
+ */
+public class V003__Repeatable implements JavaBasedMigration {
+
+	private boolean repeatable = true;
+
+	private String checksum = UUID.randomUUID().toString();
+
+	@Override
+	public void apply(MigrationContext context) {
+
+		try (Session session = context.getSession()) {
+			session.run("CREATE (n:V003__Repeatable)").consume();
+		}
+	}
+
+	public void setChecksum(String checksum) {
+		this.checksum = checksum;
+	}
+
+	@Override
+	public Optional<String> getChecksum() {
+		return Optional.of(checksum);
+	}
+
+	@Override
+	public boolean isRepeatable() {
+		return repeatable;
+	}
+
+	public void setRepeatable(boolean repeatable) {
+		this.repeatable = repeatable;
+	}
+}
+

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset5/V004__Standard.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset5/V004__Standard.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core.test_migrations.changeset5;
+
+import org.neo4j.driver.Session;
+
+import ac.simons.neo4j.migrations.core.JavaBasedMigration;
+import ac.simons.neo4j.migrations.core.MigrationContext;
+
+/**
+ * @author Michael J. Simons
+ */
+public class V004__Standard implements JavaBasedMigration {
+
+	@Override
+	public void apply(MigrationContext context) {
+
+		try (Session session = context.getSession()) {
+			session.run("CREATE (n:V004__Standard)").consume();
+		}
+	}
+}
+


### PR DESCRIPTION
This allows to mark Java based migrations to be repeatable unrelated to their version name and also makes them repeat only when their checksum changes.

This is a breaking change if you relied on the fact that Java based migrations are always repeated! If you need this, return a random checksum on each call of `getChecksum` or a different one in case you actually want the migration to be repeated.

Close #705.
