### PR TITLE
fix: Manually check for duplicate versions and don’t rely on the constraint.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
@@ -79,6 +79,16 @@ final class DiscoveryService {
 				.map(CatalogBasedMigration.class::cast)
 				.forEach(m -> writeableSchema.addAll(m.getVersion(), m.getCatalog(), m.isResetCatalog()));
 		}
+		Map<MigrationVersion, List<Migration>> groupedByVersion = migrations.stream()
+			.collect(Collectors.groupingBy(Migration::getVersion));
+		for (Map.Entry<MigrationVersion, List<Migration>> entry : groupedByVersion.entrySet()) {
+			List<Migration> v = entry.getValue();
+			if (v.size() > 1) {
+				MigrationVersion k = entry.getKey();
+				String sources = v.stream().map(Migration::getSource).collect(Collectors.joining(", "));
+				throw new MigrationsException("Duplicate version '" + k.getValue() + "' (" + sources + ")");
+			}
+		}
 		return Collections.unmodifiableList(migrations);
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
@@ -106,6 +106,7 @@ public final class MigrationVersion {
 	 * @since 1.13.3
 	 * @deprecated since 1.14.0, it should not have been public in the first place, no replacement
 	 */
+	@SuppressWarnings({"DeprecatedIsStillUsed", "squid:S1133"})
 	@Deprecated
 	public boolean isRepeatable() {
 		return repeatable;

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
@@ -641,6 +641,25 @@ class MigrationsIT extends TestBase {
 			);
 	}
 
+	@Test
+	void shouldPreventDoubleVersionsJava() {
+
+		Migrations migrations = new Migrations(MigrationsConfig.builder()
+			.withPackagesToScan("ac.simons.neo4j.migrations.core.test_migrations.changeset6").build(), driver);
+		assertThatExceptionOfType(MigrationsException.class)
+			.isThrownBy(migrations::apply)
+			.withMessage("Duplicate version '001' (ac.simons.neo4j.migrations.core.test_migrations.changeset6.V001__FirstMigration, ac.simons.neo4j.migrations.core.test_migrations.changeset6.V001__SecondMigration)");
+	}
+
+	@Test // GH-725
+	void shouldPreventDoubleVersionsCypher() {
+
+		Migrations migrations = new Migrations(MigrationsConfig.builder().withLocationsToScan("classpath:duplicate").build(), driver);
+		assertThatExceptionOfType(MigrationsException.class)
+			.isThrownBy(migrations::apply)
+			.withMessage("Duplicate version '001' (V001__Hallo.cypher, V001__Hello.cypher)");
+	}
+
 	private static List<File> createMigrationFiles(int n, File dir) throws IOException {
 		return createMigrationFiles(n, 0, dir);
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset6/V001__FirstMigration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset6/V001__FirstMigration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core.test_migrations.changeset6;
+
+import org.neo4j.driver.Session;
+
+import ac.simons.neo4j.migrations.core.JavaBasedMigration;
+import ac.simons.neo4j.migrations.core.MigrationContext;
+
+/**
+ * @author Michael J. Simons
+ */
+public class V001__FirstMigration implements JavaBasedMigration {
+
+	@SuppressWarnings({ "unused" })
+	@Override
+	public void apply(MigrationContext context) {
+
+		try (Session session = context.getSession()) {
+			assert session != null;
+			// Steps necessary for a migration
+		}
+	}
+
+}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset6/V001__SecondMigration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/test_migrations/changeset6/V001__SecondMigration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core.test_migrations.changeset6;
+
+import org.neo4j.driver.Session;
+
+import ac.simons.neo4j.migrations.core.JavaBasedMigration;
+import ac.simons.neo4j.migrations.core.MigrationContext;
+
+/**
+ * @author Michael J. Simons
+ */
+public class V001__SecondMigration implements JavaBasedMigration {
+
+	@SuppressWarnings({ "unused" })
+	@Override
+	public void apply(MigrationContext context) {
+
+		try (Session session = context.getSession()) {
+			assert session != null;
+			// Steps necessary for a migration
+		}
+	}
+
+}

--- a/neo4j-migrations-test-resources/src/main/resources/duplicate/V001__Hallo.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/duplicate/V001__Hallo.cypher
@@ -1,0 +1,1 @@
+CREATE (h:Hallo) RETURN h;

--- a/neo4j-migrations-test-resources/src/main/resources/duplicate/V001__Hello.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/duplicate/V001__Hello.cypher
@@ -1,0 +1,1 @@
+CREATE (h:Hello) RETURN h;


### PR DESCRIPTION
Closes #725.
