### PR TITLE
refactor: Add full testing support for Neo4j 5.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jVersion.java
@@ -60,9 +60,9 @@ public enum Neo4jVersion {
 	 */
 	V4_4,
 	/**
-	 * Constant for everything Neo4j 5.0
+	 * Constant for everything Neo4j 5
 	 */
-	V5_0,
+	V5,
 	/**
 	 * Constant when we assume the latest version.
 	 */
@@ -86,7 +86,7 @@ public enum Neo4jVersion {
 	private static final Set<Neo4jVersion> SERIES_4 = Arrays.stream(Neo4jVersion.values()).filter(v -> v.name().startsWith("V4_")).collect(
 		Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
 
-	private static final Set<Neo4jVersion> SERIES_5 = Arrays.stream(Neo4jVersion.values()).filter(v -> v.name().startsWith("V5_")).collect(
+	private static final Set<Neo4jVersion> SERIES_5 = Arrays.stream(Neo4jVersion.values()).filter(v -> v.name().startsWith("V5")).collect(
 		Collectors.collectingAndThen(Collectors.toSet(), EnumSet::copyOf));
 
 	/**
@@ -112,8 +112,8 @@ public enum Neo4jVersion {
 			return V4_3;
 		} else if (value.startsWith("4.4")) {
 			return V4_4;
-		} else if (value.startsWith("5.0")) {
-			return V5_0;
+		} else if (value.startsWith("5.")) {
+			return V5;
 		} else {
 			return LATEST;
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
+import org.neo4j.driver.Value;
 
 /**
  * @author Michael J. Simons
@@ -156,6 +157,11 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 	 */
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
 	List<CatalogItem<?>> findBTreeBasedItems(QueryRunner queryRunner) {
+
+		var versions = queryRunner.run(new Query("CALL dbms.components() YIELD versions")).single().get("versions").asList(Value::asString);
+		if (versions.stream().anyMatch(v -> v.startsWith("5."))) {
+			return List.of();
+		}
 
 		Map<Long, Index> indexes = findBTreeBasedIndexes(queryRunner);
 		Map<Long, Constraint> constraints = findBTreeBasedConstraints(queryRunner, indexes);

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
@@ -157,26 +157,6 @@ class MigrationsIT extends TestBase {
 	}
 
 	@Test // GH-573
-	void shouldApplyResources() {
-
-		Migrations migrations = new Migrations(MigrationsConfig.defaultConfig(), driver);
-
-		int appliedMigrations = migrations.apply(
-			Objects.requireNonNull(MigrationsIT.class.getResource("/manual_resources/V000__Create_graph.cypher")),
-			Objects.requireNonNull(MigrationsIT.class.getResource("/manual_resources/V000__Refactor_graph.xml"))
-		);
-
-		assertThat(appliedMigrations).isEqualTo(2);
-
-		try (Session session = driver.session()) {
-			long cnt = session.run(
-					"MATCH (m:Person {name:'Michael'}) -[:MAG]-> (n:Person {name:'Tina', klug: true}) RETURN count(m)")
-				.single().get(0).asLong();
-			assertThat(cnt).isOne();
-		}
-	}
-
-	@Test // GH-573
 	void shouldFailProperOnInvalidFileName() {
 
 		Migrations migrations = new Migrations(MigrationsConfig.defaultConfig(), driver);

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jImageNameSubstitutor.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jImageNameSubstitutor.java
@@ -15,6 +15,8 @@
  */
 package ac.simons.neo4j.migrations.core;
 
+import java.util.Set;
+
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.ImageNameSubstitutor;
@@ -26,15 +28,28 @@ import org.testcontainers.utility.ImageNameSubstitutor;
  */
 public final class Neo4jImageNameSubstitutor extends ImageNameSubstitutor {
 
+	private final Set<String> OFFICIALLY_SUPPORTED_ON_ARM = Set.of("4.4", "5");
+
 	@Override
 	public DockerImageName apply(DockerImageName dockerImageName) {
+
 		// don't change ryuk and neo4j 4.4+ coordinates
-		if (!dockerImageName.getRepository().startsWith("neo4j") || (dockerImageName.getRepository().startsWith("neo4j") && dockerImageName.getVersionPart().contains("4.4"))) {
+		var isNeo4jRepo = dockerImageName.getRepository().startsWith("neo4j");
+		var versionPart = dockerImageName.getVersionPart();
+		if (!isNeo4jRepo || OFFICIALLY_SUPPORTED_ON_ARM.stream().anyMatch(versionPart::startsWith)) {
 			return dockerImageName;
 		}
+		if (versionPart.startsWith("LATEST")) {
+			return DockerImageName.parse(dockerImageName.getRepository() + ":" + versionPart.replace("LATEST", "5"));
+		}
+
 		String dockerArchitecture = DockerClientFactory.instance().getInfo().getArchitecture();
 		if ("aarch64".equals(dockerArchitecture)) {
-			return DockerImageName.parse("neo4j/neo4j-arm64-experimental:" + dockerImageName.getVersionPart() + "-arm64");
+			var version = dockerImageName.getVersionPart();
+			if (version.equals("4.0")) {
+				version = "4.0.12";
+			}
+			return DockerImageName.parse("neo4j/neo4j-arm64-experimental:" + version + "-arm64");
 		}
 		return dockerImageName;
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jVersionTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jVersionTest.java
@@ -36,10 +36,10 @@ class Neo4jVersionTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "5.0.0", "Neo4j/5.0.0", "5.0.0-drop04.0", "5.0.0-aura"})
+	@ValueSource(strings = { "5.0.0", "Neo4j/5.0.0", "5.0.0-drop04.0", "5.0.0-aura", "5.1", "5.2"})
 	void shouldIdenfify5(String value) {
 		Neo4jVersion version = Neo4jVersion.of(value);
-		assertThat(version).isEqualTo(Neo4jVersion.V5_0);
+		assertThat(version).isEqualTo(Neo4jVersion.V5);
 	}
 
 	@Test
@@ -48,13 +48,13 @@ class Neo4jVersionTest {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = Neo4jVersion.class, names = { "V3_5", "V5_0", "UNDEFINED", "LATEST" }, mode = EnumSource.Mode.EXCLUDE)
+	@EnumSource(value = Neo4jVersion.class, names = { "V3_5", "V5", "UNDEFINED", "LATEST" }, mode = EnumSource.Mode.EXCLUDE)
 	void shouldIdentifyMajorVersion4(Neo4jVersion version) {
 		assertThat(version.getMajorVersion()).isEqualTo(4);
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = Neo4jVersion.class, names = { "V5_0", "UNDEFINED", "LATEST" }, mode = EnumSource.Mode.EXCLUDE)
+	@EnumSource(value = Neo4jVersion.class, names = { "V5", "UNDEFINED", "LATEST" }, mode = EnumSource.Mode.EXCLUDE)
 	void shouldParseMinor(Neo4jVersion version) {
 
 		assertThat(version.getMinorVersion()).isNotNegative();

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jVersionTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/Neo4jVersionTest.java
@@ -43,6 +43,12 @@ class Neo4jVersionTest {
 	}
 
 	@Test
+	void shouldBeLatestOnAnythingHigherThanDefined() {
+		Neo4jVersion version = Neo4jVersion.of("Neo4j/4711");
+		assertThat(version).isEqualTo(Neo4jVersion.LATEST);
+	}
+
+	@Test
 	void shouldIdentifyMajorVersion3() {
 		assertThat(Neo4jVersion.V3_5.getMajorVersion()).isEqualTo(3);
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
@@ -17,7 +17,6 @@ package ac.simons.neo4j.migrations.core;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
@@ -72,8 +71,8 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 			return this.value.toString() + (enterprise ? " (enterprise)" : "");
 		}
 	}
-	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = Collections.unmodifiableList(Arrays.asList("3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "LATEST"));
-	private static final List<String> SUPPORTED_VERSIONS_ENTERPRISE = List.of("4.4", "LATEST");
+	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = List.of("3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "5", "LATEST");
+	private static final List<String> SUPPORTED_VERSIONS_ENTERPRISE = List.of("4.4", "5", "LATEST");
 
 	@Override
 	public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
@@ -46,9 +46,9 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 			boolean testOnlyLatestNeo4j = Boolean.parseBoolean(System.getProperty("migrations.test-only-latest-neo4j", "false"));
 			if (testOnlyLatestNeo4j) {
-				return Stream.of(Arguments.of(new VersionUnderTest(Neo4jVersion.V4_4, true)));
+				return Stream.of(Arguments.of(new VersionUnderTest(Neo4jVersion.LATEST, true)));
 			}
-			EnumSet<Neo4jVersion> unsupported = EnumSet.of(Neo4jVersion.LATEST, Neo4jVersion.UNDEFINED, Neo4jVersion.V5_0);
+			EnumSet<Neo4jVersion> unsupported = EnumSet.of(Neo4jVersion.UNDEFINED);
 			return Arrays.stream(Neo4jVersion.values())
 					.filter(version -> !unsupported.contains(version))
 					.map(version -> Arguments.of(new VersionUnderTest(version, true)));
@@ -72,8 +72,8 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 			return this.value.toString() + (enterprise ? " (enterprise)" : "");
 		}
 	}
-	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = Collections.unmodifiableList(Arrays.asList("3.5", "4.1", "4.2", "4.3", "4.4", "LATEST"));
-	private static final List<String> SUPPORTED_VERSIONS_ENTERPRISE = Collections.singletonList("4.4");
+	private static final List<String> SUPPORTED_VERSIONS_COMMUNITY = Collections.unmodifiableList(Arrays.asList("3.5", "4.0", "4.1", "4.2", "4.3", "4.4", "LATEST"));
+	private static final List<String> SUPPORTED_VERSIONS_ENTERPRISE = List.of("4.4", "LATEST");
 
 	@Override
 	public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
@@ -47,7 +47,9 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 			if (testOnlyLatestNeo4j) {
 				return Stream.of(Arguments.of(new VersionUnderTest(Neo4jVersion.LATEST, true)));
 			}
-			EnumSet<Neo4jVersion> unsupported = EnumSet.of(Neo4jVersion.UNDEFINED);
+			// The exclusion of 4.0 and 4.1 here affects not every test ofc, only the ones
+			// that rely on the provider for matrix tests. 4.0 and 4.1 are EOL since July 2021 and December 2021 respectively.
+			EnumSet<Neo4jVersion> unsupported = EnumSet.of(Neo4jVersion.V4_0, Neo4jVersion.V4_1, Neo4jVersion.UNDEFINED);
 			return Arrays.stream(Neo4jVersion.values())
 					.filter(version -> !(unsupported.contains(version) || version == Neo4jVersion.LATEST))
 					.map(version -> Arguments.of(new VersionUnderTest(version, true)));

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/SkipArm64IncompatibleConfiguration.java
@@ -49,7 +49,7 @@ final class SkipArm64IncompatibleConfiguration implements InvocationInterceptor 
 			}
 			EnumSet<Neo4jVersion> unsupported = EnumSet.of(Neo4jVersion.UNDEFINED);
 			return Arrays.stream(Neo4jVersion.values())
-					.filter(version -> !unsupported.contains(version))
+					.filter(version -> !(unsupported.contains(version) || version == Neo4jVersion.LATEST))
 					.map(version -> Arguments.of(new VersionUnderTest(version, true)));
 		}
 	}

--- a/neo4j-migrations-test-resources/src/main/resources/ee/V01__Use_some_enterprise_features.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/ee/V01__Use_some_enterprise_features.cypher
@@ -1,1 +1,1 @@
-CREATE CONSTRAINT constraint_name ON ()-[like:LIKED]-() ASSERT exists(like.day);
+CREATE CONSTRAINT constraint_name FOR ()-[like:LIKED]-() REQUIRE like.day IS NOT NULL;


### PR DESCRIPTION
This is partially from https://github.com/michael-simons/neo4j-migrations/pull/699 which needs rebasing.
Summary: There is a 4.0 ARM version, we need to deal with the faster release pace of Neo4j 5 (it is not sustainable to add a new enum value each month) and we also want to have `LATEST` support in the image name substitutor.
