### PR TITLE
feat: Add `migrateBTreeIndexes` cmd to CLI.

### DIFF
--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
@@ -48,6 +48,13 @@ abstract class ConnectedCommand implements Callable<Integer> {
 	 */
 	abstract MigrationsCli getParent();
 
+	/**
+	 * @return {@literal true} to enforce silence (no complaining about missing locations.
+	 */
+	boolean forceSilence() {
+		return false;
+	}
+
 	@Override
 	public Integer call() {
 
@@ -56,7 +63,7 @@ abstract class ConnectedCommand implements Callable<Integer> {
 
 		MigrationsConfig config;
 		try {
-			config = migrationsCli.getConfig(this instanceof RunCommand);
+			config = migrationsCli.getConfig(forceSilence());
 		} catch (IllegalArgumentException e) {
 			MigrationsCli.LOGGER.log(Level.SEVERE, e.getMessage());
 			return CommandLine.ExitCode.USAGE;

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommand.java
@@ -87,7 +87,7 @@ public class MigrateBTreeIndexesCommand extends ConnectedCommand {
 					case TEXT -> Index.Type.TEXT;
 				}));
 			String readableMappings = mappings.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(System.lineSeparator()));
-			MigrationsCli.LOGGER.log(Level.INFO, "Using the following mapping:" + System.lineSeparator() + "{0}", readableMappings);
+			MigrationsCli.LOGGER.log(Level.INFO, "Using the following mapping:{0}{1}", new Object[] {System.lineSeparator(), readableMappings});
 		}
 
 		MigrateBTreeIndexes refactoring;
@@ -99,9 +99,9 @@ public class MigrateBTreeIndexesCommand extends ConnectedCommand {
 		refactoring = refactoring.withTypeMapping(typeMapping).withIncludes(includes).withExcludes(excludes);
 		Counters counters = migrations.apply(refactoring);
 		if (replace) {
-			MigrationsCli.LOGGER.log(Level.INFO, "Deleted {0} BTree based indexes and {0} constraints and replaced them with {0} new indexes and {0} constraints.", new Object[] {counters.indexesRemoved(), counters.constraintsRemoved(), counters.indexesAdded(), counters.constraintsAdded()});
+			MigrationsCli.LOGGER.log(Level.INFO, "Deleted {0} BTree based indexes and {1} constraints and replaced them with {2} new indexes and {3} constraints.", new Object[] {counters.indexesRemoved(), counters.constraintsRemoved(), counters.indexesAdded(), counters.constraintsAdded()});
 		} else {
-			MigrationsCli.LOGGER.log(Level.INFO, "Added {0} new indexes and {0} constraints.", new Object[] {counters.indexesAdded(), counters.constraintsAdded()});
+			MigrationsCli.LOGGER.log(Level.INFO, "Added {0} new indexes and {1} constraints.", new Object[] {counters.indexesAdded(), counters.constraintsAdded()});
 		}
 		return 0;
 	}

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.catalog.Index;
+import ac.simons.neo4j.migrations.core.refactorings.Counters;
+import ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes;
+import picocli.CommandLine;
+
+/**
+ * A hidden command for accessing the {@link MigrateBTreeIndexes} refactoring directly.
+ *
+ * @author Michael J. Simons
+ * @since 1.15.0
+ */
+@CommandLine.Command(name = "migrateBTreeIndexes", description = "Migrates existing B-tree indexes and constraints backed by such indexes to Neo4j 5.0+ and higher supported indexes. By default, new indexes will be created in parallel with a suffix attached to their name.", hidden = true)
+public class MigrateBTreeIndexesCommand extends ConnectedCommand {
+
+	enum IndexType {
+		RANGE, TEXT, POINT
+	}
+
+	@CommandLine.ParentCommand
+	private MigrationsCli parent;
+
+	@CommandLine.Option(names = "suffix", showDefaultValue = CommandLine.Help.Visibility.ALWAYS, defaultValue = MigrateBTreeIndexes.DEFAULT_SUFFIX, description = "The suffix for the new indexes created in parallel.")
+	private String suffix;
+
+	@CommandLine.Option(names = "replace", showDefaultValue = CommandLine.Help.Visibility.ALWAYS, defaultValue = "false", description = "Drops existing B-tree indexes and constraints and creates new one with the old names.")
+	private boolean replace;
+
+	@CommandLine.Option(names = "--mapping", description = "Use the given type for the index or constraint with the matching name.\nSpecify multiple times for multiple mappings.")
+	Map<String, IndexType> mappings;
+
+	@CommandLine.Option(names = "--exclude", description = "Names of indexes and constraints to exclude in migration.\nSpecify multiple times for multiple excludes.")
+	private Set<String> excludes;
+
+	@CommandLine.Option(names = "--include", description = "Names of indexes and constraints to include in migration.\nSpecify multiple times for multiple excludes.")
+	private Set<String> includes;
+
+	@Override
+	public MigrationsCli getParent() {
+		return parent;
+	}
+
+	@Override
+	boolean forceSilence() {
+		return true;
+	}
+
+	@Override
+	Integer withMigrations(Migrations migrations) {
+
+		if (excludes != null) {
+			MigrationsCli.LOGGER.log(Level.INFO, "Excluding the following schema items: {0}", new Object[] {String.join(", ", excludes)});
+		}
+
+		if (includes != null) {
+			MigrationsCli.LOGGER.log(Level.INFO, "Including the following schema items: {0}", new Object[] {String.join(", ", includes)});
+		}
+
+		Map<String, Index.Type> typeMapping = null;
+		if (mappings != null) {
+			typeMapping = mappings.entrySet()
+				.stream().collect(Collectors.toMap(Map.Entry::getKey, e -> switch (e.getValue()) {
+					case RANGE -> Index.Type.PROPERTY;
+					case POINT -> Index.Type.POINT;
+					case TEXT -> Index.Type.TEXT;
+				}));
+			String readableMappings = mappings.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(System.lineSeparator()));
+			MigrationsCli.LOGGER.log(Level.INFO, "Using the following mapping:" + System.lineSeparator() + "{0}", readableMappings);
+		}
+
+		MigrateBTreeIndexes refactoring;
+		if (replace) {
+			refactoring = MigrateBTreeIndexes.replaceBTreeIndexes();
+		} else {
+			refactoring = MigrateBTreeIndexes.createFutureIndexes(suffix);
+		}
+		refactoring = refactoring.withTypeMapping(typeMapping).withIncludes(includes).withExcludes(excludes);
+		Counters counters = migrations.apply(refactoring);
+		if (replace) {
+			MigrationsCli.LOGGER.log(Level.INFO, "Deleted {0} BTree based indexes and {0} constraints and replaced them with {0} new indexes and {0} constraints.", new Object[] {counters.indexesRemoved(), counters.constraintsRemoved(), counters.indexesAdded(), counters.constraintsAdded()});
+		} else {
+			MigrationsCli.LOGGER.log(Level.INFO, "Added {0} new indexes and {0} constraints.", new Object[] {counters.indexesAdded(), counters.constraintsAdded()});
+		}
+		return 0;
+	}
+}

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -68,7 +68,7 @@ import org.neo4j.driver.Logging;
 	name = "neo4j-migrations",
 	mixinStandardHelpOptions = true,
 	description = "Migrates Neo4j databases.",
-	subcommands = { CleanCommand.class, AutoComplete.GenerateCompletion.class, CommandLine.HelpCommand.class, InfoCommand.class, InitCommand.class, MigrateCommand.class, RunCommand.class, ShowCatalogCommand.class, ValidateCommand.class },
+	subcommands = { CleanCommand.class, AutoComplete.GenerateCompletion.class, CommandLine.HelpCommand.class, InfoCommand.class, InitCommand.class, MigrateBTreeIndexesCommand.class, MigrateCommand.class, RunCommand.class, ShowCatalogCommand.class, ValidateCommand.class },
 	versionProvider = ManifestVersionProvider.class,
 	defaultValueProvider = CommonEnvVarDefaultProvider.class
 )

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/RunCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/RunCommand.java
@@ -52,6 +52,11 @@ final class RunCommand extends ConnectedCommand {
 	}
 
 	@Override
+	boolean forceSilence() {
+		return true;
+	}
+
+	@Override
 	Integer withMigrations(Migrations migrations) {
 
 		int cnt = migrations.apply(migrationsToRun);

--- a/neo4j-migrations-cli/src/main/resources/logging.properties
+++ b/neo4j-migrations-cli/src/main/resources/logging.properties
@@ -22,5 +22,9 @@ ac.simons.neo4j.migrations.cli.MigrationsCli.handlers = ac.simons.neo4j.migratio
 ac.simons.neo4j.migrations.cli.MigrationsCli.level = INFO
 ac.simons.neo4j.migrations.cli.MigrationsCli.useParentHandlers = false
 
+ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes.handlers = ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler
+ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes.level = INFO
+ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes.useParentHandlers = false
+
 ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler.level = INFO
 ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleHandler.formatter = ac.simons.neo4j.migrations.cli.internal.MigrationsCliConsoleFormatter

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommandTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrateBTreeIndexesCommandTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.mockito.ArgumentCaptor;
+
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.catalog.Index;
+import ac.simons.neo4j.migrations.core.refactorings.Counters;
+import ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes;
+import ac.simons.neo4j.migrations.core.refactorings.Refactoring;
+
+/**
+ * @author Michael J. Simons
+ */
+class MigrateBTreeIndexesCommandTest {
+
+	private final ArgumentCaptor<MigrateBTreeIndexes> captor = ArgumentCaptor.forClass(MigrateBTreeIndexes.class);
+
+	@Test
+	void shouldDefaultToNotReplace() throws Exception {
+
+		Migrations migrations = mock(Migrations.class);
+		when(migrations.apply(any(Refactoring.class))).thenReturn(mock(Counters.class));
+
+		MigrateBTreeIndexesCommand cmd = new MigrateBTreeIndexesCommand();
+		cmd.withMigrations(migrations);
+
+		verify(migrations).apply(captor.capture());
+
+		MigrateBTreeIndexes refactoring = captor.getValue();
+		Field dropOldIndexesField = refactoring.getClass().getDeclaredField("dropOldIndexes");
+		dropOldIndexesField.setAccessible(true);
+
+		boolean dropOldIndexes = (boolean) dropOldIndexesField.get(refactoring);
+		assertThat(dropOldIndexes).isFalse();
+	}
+
+	@Test
+	void shouldConfigureSuffix() throws Exception {
+
+		Migrations migrations = mock(Migrations.class);
+		when(migrations.apply(any(Refactoring.class))).thenReturn(mock(Counters.class));
+
+		MigrateBTreeIndexesCommand cmd = new MigrateBTreeIndexesCommand();
+		setValue(cmd, "suffix", "bar");
+		cmd.withMigrations(migrations);
+
+		verify(migrations).apply(captor.capture());
+
+		MigrateBTreeIndexes refactoring = captor.getValue();
+
+		Field field = refactoring.getClass().getDeclaredField("suffix");
+		field.setAccessible(true);
+		String suffix = (String) field.get(refactoring);
+		assertThat(suffix).isEqualTo("bar");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void shouldApplyOptions() throws Exception {
+
+		Migrations migrations = mock(Migrations.class);
+		when(migrations.apply(any(Refactoring.class))).thenReturn(mock(Counters.class));
+
+		MigrateBTreeIndexesCommand cmd = new MigrateBTreeIndexesCommand();
+		setValue(cmd, "replace", true);
+		setValue(cmd, "excludes", Set.of("a", "b"));
+		setValue(cmd, "includes", Set.of("c", "d"));
+		setValue(cmd, "mappings", Map.of("aPoint", MigrateBTreeIndexesCommand.IndexType.POINT));
+		cmd.withMigrations(migrations);
+
+		verify(migrations).apply(captor.capture());
+
+		MigrateBTreeIndexes refactoring = captor.getValue();
+
+		Field field;
+
+		field = refactoring.getClass().getDeclaredField("dropOldIndexes");
+		field.setAccessible(true);
+		boolean dropOldIndexes = (boolean) field.get(refactoring);
+		assertThat(dropOldIndexes).isTrue();
+
+		field = refactoring.getClass().getDeclaredField("excludes");
+		field.setAccessible(true);
+		Set<String> excludes = (Set<String>) field.get(refactoring);
+		assertThat(excludes).containsExactly("a", "b");
+
+		field = refactoring.getClass().getDeclaredField("includes");
+		field.setAccessible(true);
+		Set<String> includes = (Set<String>) field.get(refactoring);
+		assertThat(includes).containsExactly("c", "d");
+
+		field = refactoring.getClass().getDeclaredField("typeMapping");
+		field.setAccessible(true);
+		Map<String, Index.Type> typeMapping = (Map<String, Index.Type>) field.get(refactoring);
+		assertThat(typeMapping).containsEntry("aPoint", Index.Type.POINT);
+	}
+
+	private static void setValue(MigrateBTreeIndexesCommand cmd, String field, Object value) {
+		ReflectionSupport
+			.findFields(MigrateBTreeIndexesCommand.class, f -> f.getName().equals(field), HierarchyTraversalMode.TOP_DOWN)
+			.forEach(f -> {
+				f.setAccessible(true);
+				try {
+					f.set(cmd, value);
+				} catch (IllegalAccessException e) {
+					throw new RuntimeException(e);
+				}
+			});
+	}
+}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
@@ -245,7 +245,7 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 				counters = counters.add(new DefaultCounters(tx.run(new Query(renderer.render(migratedItem, config))).consume().counters()));
 			}
 
-			if (!dropOldIndexes && LOGGER.isLoggable(Level.INFO)) {
+			if (!dropOldIndexes && LOGGER.isLoggable(Level.INFO) && (counters.indexesAdded() + counters.constraintsAdded()) > 0) {
 				LOGGER.log(Level.INFO, "Future indexes have been created. Use the following statements to drop all BTREE based constraints and indexes:{0}", dropStatements);
 			}
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/MigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/MigrateBTreeIndexes.java
@@ -91,7 +91,7 @@ public interface MigrateBTreeIndexes extends Refactoring {
 	MigrateBTreeIndexes withExcludes(Collection<String> excludes);
 
 	/**
-	 * Configures an include list. An empty or {@literal null} value disables the include-list checking. A non empty
+	 * Configures an include list. An empty or {@literal null} value disables the include-list checking. A non-empty
 	 * list will configure the refactoring in such a way that only items that are on the list are migrated.
 	 *
 	 * @param newIncludes New includes


### PR DESCRIPTION
Adds the `MigrateBTreeIndexes` refactoring as hidden but directly accesible command to the CLI.

Retrieve help about it via

```
neo4j-migrations help migrateBTreeIndexes
```

This can be used without any other refactoring or configuration. Username, password and database url are required though.
