### PR TITLE
fix: Remove automatic automatic-module name insertion for core module.

### DIFF
--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -116,6 +116,24 @@
 	<build>
 		<plugins>
 			<plugin>
+				<!--
+				This module has a proper module, we must not add the automatic module entry to the jar. The maven-jar-plugin
+				must also be declared _before_ the maven-shade-plugin, otherwise no sources will be available for the javadoc-plugin
+				for whatever god-damn reasons I dare not to ask about.
+				 -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>${maven-jar-plugin.version}</version>
+				<configuration combine.self="override">
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							<addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
@@ -211,20 +229,6 @@
 						<phase>verify</phase>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<!-- This module has a proper module, we must not add the automatic module entry to the jar -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>${maven-jar-plugin.version}</version>
-				<configuration combine.self="override">
-					<archive>
-						<manifest>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-							<addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
-						</manifest>
-					</archive>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -123,7 +123,6 @@
 				 -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>${maven-jar-plugin.version}</version>
 				<configuration combine.self="override">
 					<archive>
 						<manifest>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -168,6 +168,25 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<module>
+								<moduleInfoFile>src/main/java/module-info.java</moduleInfoFile>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<version>${japicmp-maven-plugin.version}</version>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -30,7 +30,6 @@
 	<description>The Core API of Neo4j-Migrations.</description>
 
 	<properties>
-		<java-module-name>ac.simons.neo4j.migrations.core</java-module-name>
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 
@@ -212,6 +211,20 @@
 						<phase>verify</phase>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<!-- This module has a proper module, we must not add the automatic module entry to the jar -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>${maven-jar-plugin.version}</version>
+				<configuration combine.self="override">
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							<addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+						</manifest>
+					</archive>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/neo4j-migrations-core/src/main/java/module-info.java
+++ b/neo4j-migrations-core/src/main/java/module-info.java
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import ac.simons.neo4j.migrations.core.CypherResourceBasedMigrationProvider;
-import ac.simons.neo4j.migrations.core.DefaultCatalogBasedMigrationProvider;
-import ac.simons.neo4j.migrations.core.ResourceBasedMigrationProvider;
 
 /**
  * Neo4j-Migrations core module.
@@ -38,6 +35,8 @@ module ac.simons.neo4j.migrations.core {
 	exports ac.simons.neo4j.migrations.core.catalog;
 	exports ac.simons.neo4j.migrations.core.refactorings;
 
-	provides ResourceBasedMigrationProvider with CypherResourceBasedMigrationProvider, DefaultCatalogBasedMigrationProvider;
-	uses ResourceBasedMigrationProvider;
+	provides ac.simons.neo4j.migrations.core.ResourceBasedMigrationProvider with
+		ac.simons.neo4j.migrations.core.CypherResourceBasedMigrationProvider,
+		ac.simons.neo4j.migrations.core.DefaultCatalogBasedMigrationProvider;
+	uses ac.simons.neo4j.migrations.core.ResourceBasedMigrationProvider;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
 		<mavengem-wagon.version>1.0.3</mavengem-wagon.version>
 		<migrations.test-only-latest-neo4j>false</migrations.test-only-latest-neo4j>
 		<mockito.version>4.9.0</mockito.version>
+		<moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
 		<native.maven.plugin.version>0.9.19</native.maven.plugin.version>
 		<neo4j-java-driver.version>5.3.0</neo4j-java-driver.version>
 		<neo4j-migrations.previous.version>2.0.0</neo4j-migrations.previous.version>
@@ -619,6 +620,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>${maven-shade-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.moditect</groupId>
+					<artifactId>moditect-maven-plugin</artifactId>
+					<version>${moditect-maven-plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<guava.version>31.1-jre</guava.version>
 		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 		<japicmp-maven-plugin.version>0.17.1</japicmp-maven-plugin.version>
-		<java-module-name />
+		<java-module-name/>
 		<java.version>17</java.version>
 		<junit-jupiter-causal-cluster-testcontainer-extension.version>2022.1.3</junit-jupiter-causal-cluster-testcontainer-extension.version>
 		<!-- to be overridden in sub modules -->
@@ -791,7 +791,7 @@
 								<requireJavaVersion>
 									<version>${java.version}</version>
 								</requireJavaVersion>
-								<DependencyConvergence />
+								<DependencyConvergence/>
 								<requireMavenVersion>
 									<version>${maven.version}</version>
 								</requireMavenVersion>
@@ -925,9 +925,9 @@
 					<attributes>
 						<icons>font</icons>
 						<toc>left</toc>
-						<setanchors />
-						<idprefix />
-						<idseparator />
+						<setanchors/>
+						<idprefix/>
+						<idseparator/>
 						<imagesdir>img</imagesdir>
 						<neo4j-java-driver-version>${neo4j-java-driver.version}</neo4j-java-driver-version>
 						<neo4j-migrations.version>${project.version}</neo4j-migrations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -850,6 +850,7 @@
 				<configuration>
 					<archive>
 						<manifest>
+							<addDefaultEntries>true</addDefaultEntries>
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							<addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
 						</manifest>


### PR DESCRIPTION
If a module has a proper `module-info.java` declaration we must not insert into the Jar file via `Automatic-Module-Name`, otherwise the latter will have precent and thus putting all the efforts of the module into vain.
