### PR TITLE
issue/1x deps 20221219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
 		<maven-install-plugin.version>3.1.0</maven-install-plugin.version>
-		<maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
+		<maven-invoker-plugin.version>3.4.0</maven-invoker-plugin.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 		<maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<covered-ratio-complexity>0.5</covered-ratio-complexity>
 		<covered-ratio-instructions>0.5</covered-ratio-instructions>
 		<cypher-dsl.version>2022.8.1</cypher-dsl.version>
-		<docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
+		<docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>
 		<error_prone_annotations.version>2.16</error_prone_annotations.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<graalvm.version>21.3.2</graalvm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<checker-qual.version>3.28.0</checker-qual.version>
 		<checkstyle.version>10.5.0</checkstyle.version>
 		<classgraph.version>4.8.152</classgraph.version>
-		<compile-testing.version>0.20</compile-testing.version>
+		<compile-testing.version>0.21.0</compile-testing.version>
 		<covered-ratio-complexity>0.5</covered-ratio-complexity>
 		<covered-ratio-instructions>0.5</covered-ratio-instructions>
 		<cypher-dsl.version>2022.8.1</cypher-dsl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.23.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-		<byte-buddy.version>1.12.19</byte-buddy.version>
+		<byte-buddy.version>1.12.20</byte-buddy.version>
 		<checker-qual.version>3.28.0</checker-qual.version>
 		<checkstyle.version>10.5.0</checkstyle.version>
 		<classgraph.version>4.8.152</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven.version>3.8.6</maven.version>
 		<mavengem-wagon.version>1.0.3</mavengem-wagon.version>
 		<migrations.test-only-latest-neo4j>false</migrations.test-only-latest-neo4j>
-		<mockito.version>4.9.0</mockito.version>
+		<mockito.version>4.10.0</mockito.version>
 		<native.maven.plugin.version>0.9.19</native.maven.plugin.version>
 		<neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
 		<neo4j-migrations.previous.version>1.15.1</neo4j-migrations.previous.version>


### PR DESCRIPTION
- build(deps): Bump byte-buddy.version from 1.12.19 to 1.12.20 (#789)
- build(deps): Bump mockito.version from 4.9.0 to 4.10.0 (#790)
- build(deps): Bump compile-testing from 0.20 to 0.21.0 (#792)
- build(deps): Bump maven-invoker-plugin from 3.3.0 to 3.4.0 (#793)
- build(deps): Bump docker-maven-plugin from 0.40.2 to 0.40.3 (#791)
