### PR TITLE
issue/backports 20230116

### DIFF
--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/RunCommandTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/RunCommandTest.java
@@ -54,7 +54,7 @@ class RunCommandTest {
 
 	private static void setMigrations(RunCommand cmd, URL url) {
 		ReflectionSupport
-			.findFields(RunCommand.class, f -> f.getName().equals("migrations"), HierarchyTraversalMode.TOP_DOWN)
+			.findFields(RunCommand.class, f -> f.getName().equals("migrationsToRun"), HierarchyTraversalMode.TOP_DOWN)
 			.forEach(f -> {
 				f.setAccessible(true);
 				try {

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
 			<dependency>
 				<groupId>net.java.dev.jna</groupId>
 				<artifactId>jna</artifactId>
-				<version>5.12.1</version>
+				<version>5.13.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apiguardian</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
 		<junit.jupiter.version>5.9.1</junit.jupiter.version>
 		<license-maven-plugin.version>4.2.rc2</license-maven-plugin.version>
 		<maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
-		<maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<covered-ratio-instructions>0.5</covered-ratio-instructions>
 		<cypher-dsl.version>2022.8.3</cypher-dsl.version>
 		<docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>
-		<error_prone_annotations.version>2.17.0</error_prone_annotations.version>
+		<error_prone_annotations.version>2.18.0</error_prone_annotations.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<graalvm.version>21.3.2</graalvm.version>
 		<guava.version>31.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.24.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-		<byte-buddy.version>1.12.21</byte-buddy.version>
+		<byte-buddy.version>1.12.22</byte-buddy.version>
 		<checker-qual.version>3.29.0</checker-qual.version>
 		<checkstyle.version>10.6.0</checkstyle.version>
 		<classgraph.version>4.8.154</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven.version>3.8.7</maven.version>
 		<mavengem-wagon.version>1.0.3</mavengem-wagon.version>
 		<migrations.test-only-latest-neo4j>false</migrations.test-only-latest-neo4j>
-		<mockito.version>4.11.0</mockito.version>
+		<mockito.version>5.0.0</mockito.version>
 		<native.maven.plugin.version>0.9.19</native.maven.plugin.version>
 		<neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
 		<neo4j-migrations.previous.version>1.15.3</neo4j-migrations.previous.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 		<maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
-		<maven-project-info-reports-plugin.version>3.4.1</maven-project-info-reports-plugin.version>
+		<maven-project-info-reports-plugin.version>3.4.2</maven-project-info-reports-plugin.version>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
 		<maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>


### PR DESCRIPTION
- build(deps): Bump mockito.version from 4.11.0 to 5.0.0 (#817)
- build(deps-dev): Bump error_prone_annotations from 2.17.0 to 2.18.0 (#821)
- build(deps): Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 (#822)
- build(deps): Bump jna from 5.12.1 to 5.13.0 (#823)
- build(deps): Bump maven-project-info-reports-plugin from 3.4.1 to 3.4.2 (#824)
- build(deps): Bump byte-buddy.version from 1.12.21 to 1.12.22 (#826)
