### PR TITLE
issue/backports 20230206

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.24.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-		<byte-buddy.version>1.12.22</byte-buddy.version>
+		<byte-buddy.version>1.12.23</byte-buddy.version>
 		<checker-qual.version>3.30.0</checker-qual.version>
 		<checkstyle.version>10.6.0</checkstyle.version>
 		<classgraph.version>4.8.154</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
 		<objenesis.version>3.3</objenesis.version>
 		<os-maven-plugin.version>1.7.1</os-maven-plugin.version>
-		<picocli.version>4.7.0</picocli.version>
+		<picocli.version>4.7.1</picocli.version>
 		<powermock.version>2.0.9</powermock.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.docs.branch>main</project.build.docs.branch>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
 		<byte-buddy.version>1.12.23</byte-buddy.version>
 		<checker-qual.version>3.30.0</checker-qual.version>
-		<checkstyle.version>10.6.0</checkstyle.version>
+		<checkstyle.version>10.7.0</checkstyle.version>
 		<classgraph.version>4.8.154</classgraph.version>
 		<compile-testing.version>0.21.0</compile-testing.version>
 		<covered-ratio-complexity>0.5</covered-ratio-complexity>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven.version>3.8.7</maven.version>
 		<mavengem-wagon.version>1.0.3</mavengem-wagon.version>
 		<migrations.test-only-latest-neo4j>false</migrations.test-only-latest-neo4j>
-		<mockito.version>5.0.0</mockito.version>
+		<mockito.version>5.1.0</mockito.version>
 		<native.maven.plugin.version>0.9.19</native.maven.plugin.version>
 		<neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
 		<neo4j-migrations.previous.version>1.16.0</neo4j-migrations.previous.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<assertj.version>3.24.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
 		<byte-buddy.version>1.12.22</byte-buddy.version>
-		<checker-qual.version>3.29.0</checker-qual.version>
+		<checker-qual.version>3.30.0</checker-qual.version>
 		<checkstyle.version>10.6.0</checkstyle.version>
 		<classgraph.version>4.8.154</classgraph.version>
 		<compile-testing.version>0.21.0</compile-testing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<quarkus.version>2.13.7.Final</quarkus.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
-		<sortpom-maven-plugin.version>3.2.0</sortpom-maven-plugin.version>
+		<sortpom-maven-plugin.version>3.2.1</sortpom-maven-plugin.version>
 		<spring-boot.version>2.7.8</spring-boot.version>
 		<spring-data-neo4j.version>6.3.7</spring-data-neo4j.version>
 		<system-lambda.version>1.2.1</system-lambda.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<archunit.version>1.0.1</archunit.version>
 		<artifactsDir>neo4j-migrations-cli/target</artifactsDir>
 		<asciidoctor-maven-plugin.version>2.2.2</asciidoctor-maven-plugin.version>
-		<asciidoctorj-diagram.version>2.2.3</asciidoctorj-diagram.version>
+		<asciidoctorj-diagram.version>2.2.4</asciidoctorj-diagram.version>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.24.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
- build(deps): Bump sortpom-maven-plugin from 3.2.0 to 3.2.1 (#843)
- build(deps): Bump mockito.version from 5.0.0 to 5.1.0 (#846)
- build(deps): Bump picocli from 4.7.0 to 4.7.1 (#847)
- build(deps-dev): Bump checker-qual from 3.29.0 to 3.30.0 (#851)
- build(deps): Bump byte-buddy.version from 1.12.22 to 1.12.23 (#852)
- build(deps): Bump asciidoctorj-diagram from 2.2.3 to 2.2.4 (#848)
- build(deps): Bump checkstyle from 10.6.0 to 10.7.0 (#853)
