### PR TITLE
issue/backports 20230213

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<assertj.version>3.24.1</assertj.version>
 		<build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-		<byte-buddy.version>1.12.23</byte-buddy.version>
+		<byte-buddy.version>1.13.0</byte-buddy.version>
 		<checker-qual.version>3.30.0</checker-qual.version>
 		<checkstyle.version>10.7.0</checkstyle.version>
 		<classgraph.version>4.8.154</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<covered-ratio-complexity>0.5</covered-ratio-complexity>
 		<covered-ratio-instructions>0.5</covered-ratio-instructions>
 		<cypher-dsl.version>2022.8.3</cypher-dsl.version>
-		<docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>
+		<docker-maven-plugin.version>0.41.0</docker-maven-plugin.version>
 		<error_prone_annotations.version>2.18.0</error_prone_annotations.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<graalvm.version>21.3.2</graalvm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven.version>3.8.7</maven.version>
 		<mavengem-wagon.version>1.0.3</mavengem-wagon.version>
 		<migrations.test-only-latest-neo4j>false</migrations.test-only-latest-neo4j>
-		<mockito.version>5.1.0</mockito.version>
+		<mockito.version>5.1.1</mockito.version>
 		<native.maven.plugin.version>0.9.19</native.maven.plugin.version>
 		<neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
 		<neo4j-migrations.previous.version>1.16.1</neo4j-migrations.previous.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-		<maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+		<maven-deploy-plugin.version>3.1.0</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>


### PR DESCRIPTION
- build(deps): Bump mockito.version from 5.1.0 to 5.1.1 (#856)
- build(deps): Bump byte-buddy.version from 1.12.23 to 1.13.0 (#857)
- build(deps): Bump docker-maven-plugin from 0.40.3 to 0.41.0 (#862)
- build(deps): Bump maven-deploy-plugin from 3.0.0 to 3.1.0 (#863)
