### PR TITLE
feat: Add `delete` operation.

### DIFF
--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -774,7 +774,7 @@ not to do anything in a given context. The migration will be dutifully recorded 
 Given that your application needs to support multiple versions of Neo4j, including versions that didn't exist when you created
 your application originally and you might have invalid Cypher now in potentially already applied migrations you can do the following
 
-* Create subfolders in your migration locations or configure additional locations
+* Create sub-folders in your migration locations or configure additional locations
 * Duplicate the migrations that contain Cypher that is problematic in newer Neo4j versions
 * Keep the names of the migrations identical and distribute them accordingly in these folders
 * Add a precondition matching only older versions of Neo4j to one and keep the rest unaltered
@@ -785,3 +785,16 @@ Thus, you support the following scenarios:
 * On older database versions against which your application already ran, nothing will change; the migration with the fixed syntax will be skipped
 * Same for a clean slate on older database versions
 * On the newer database version, only the fixed syntax migration will be applied.
+
+[[concepts_repairing_broken_chains]]
+== Repairing migrations
+
+Sometimes things will break, either on purpose or by accident. When a migration chain is broken, it will fail to validate. This can happen for various reasons:
+
+* You change a Cypher script file after it has been applied and its application has been successfully recorded
+* You migrate your database as part of your application startup and not with a CI process and used different versions of your application with a different set of migration scripts and classes
+* You delete individual script files or classes
+
+In all those cases, the chain of applied migrations won't validate with the current set of migrations discovered. Apart from using the xref:usage.adoc#usage_common_clean[`clean` operation] which would remove the whole chain from your database and inevitable leading to all migrations to be re-applied, you several options to repair your database:
+
+* Delete the offending migrations - those are all for which no script or class can be resolved anymore - individually from the database with the xref:usage.adoc#usage_common_delete[`delete` operation].

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -4,28 +4,6 @@
 [[usage_common]]
 == Common operations
 
-[[usage_common_clean]]
-=== Clean
-
-`clean` applies by default to the xref:concepts.adoc#concepts_separate-databases[schema database].
-It will remove Neo4j-Migrations related nodes and relationships.
-If there is no schema database selected, it works on the optional target database.
-If this isn't configured either, the users home database will be used.
-
-The clean operation will search for
-
-* Migration chains (those are the nodes containing information about the applied migrations)
-* Any log from this Neo4j-Migrations
-* Any constraints created by Neo4j-Migrations
-
-and will delete and drop them in that order.
-This is a *destructive* operation, so make sure not to apply it to your production database without thinking at least twice.
-It cannot be undone via Neo4j-Migrations.
-
-The operation takes in a boolean parameter.
-When set to `false`, only the xref:concepts.adoc#concepts_chain[migration chain] for the currently configured target database will be deleted.
-When set to `true`, all objects created by Neo4j-Migrations will be deleted.
-
 [[usage_common_info]]
 === Info
 
@@ -50,6 +28,35 @@ where migrations are missing, have not been applied, applied in a different orde
 The validation result provides an additional operation `needsRepair()`.
 In case the result is invalid you might check if it needs repair.
 If not, you can just call the xref:usage.adoc#usage_common_migrate[apply operation] to turn the database into a valid state.
+
+[[usage_common_clean]]
+=== Clean
+
+`clean` applies by default to the xref:concepts.adoc#concepts_separate-databases[schema database].
+It will remove Neo4j-Migrations related nodes and relationships.
+If there is no schema database selected, it works on the optional target database.
+If this isn't configured either, the users home database will be used.
+
+The clean operation will search for
+
+* Migration chains (those are the nodes containing information about the applied migrations)
+* Any log from this Neo4j-Migrations
+* Any constraints created by Neo4j-Migrations
+
+and will delete and drop them in that order.
+This is a *destructive* operation, so make sure not to apply it to your production database without thinking at least twice.
+It cannot be undone via Neo4j-Migrations.
+
+The operation takes in a boolean parameter.
+When set to `false`, only the xref:concepts.adoc#concepts_chain[migration chain] for the currently configured target database will be deleted.
+When set to `true`, all objects created by Neo4j-Migrations will be deleted.
+
+[[usage_common_delete]]
+=== Delete
+
+The `delete` operation comes in handy when the migrations fail to <<usage_common_validate, validate>>. This might be the case when you accidentally or on purpose deleted script files or refactored Java based migrations away. The `delete` operation takes in the unique version or the name of a Cypher script file or a Java class, looks for a migration in the migration chain fitting that description and deletes it. If it was the last migration in the chain, the previous one will be the new last, otherwise the previous migration will point to the next one.
+
+Using the `delete` operation is one way of xref:concepts.adoc#concepts_repairing_broken_chains[repairing broken migration chains].
 
 == CLI
 
@@ -122,6 +129,7 @@ Migrates Neo4j databases.
 Commands:
   clean           Removes Neo4j-Migration specific data from the selected
                     schema database
+  delete          Deletes a migration from the chain of applied migrations
   help            Displays help information about the specified command
   info            Retrieves all applied and pending information, prints them
                     and exits.
@@ -340,7 +348,7 @@ All resolved migrations have been applied to the default database.
 
 === Using the CLI as a script runner
 
-The CLI can be used as a simple runner for migrations scripts as well. The only necessity is that all scripts have well-defined names according to the format described <<concepts_migrations, here>>:
+The CLI can be used as a simple runner for migrations scripts as well. The only necessity is that all scripts have well-defined names according to the format described xref:concepts.adoc#concepts_migrations[here]:
 
 [source,console,subs="verbatim,attributes"]
 ----
@@ -437,8 +445,10 @@ info:: Returns information about the context, the database, all applied and all 
 apply:: Applies all discovered migrations
 validate:: Validates the database against the resolved migrations
 clean:: Cleans the selected schema database from every metadata created by this tool
+delete:: Removes a single migration from the chain of applied migrations
 
-The same operations are available in the CLI and Maven-Plugin. The corresponding starter for Spring Boot respectively the Quarkus extension will automatically run `apply`.
+All operations are available in the CLI and Maven-Plugin, except for the `delete` operation, which is only in the Core-API and the CLI.
+The corresponding starter for Spring Boot respectively the Quarkus extension will automatically run `apply`.
 
 `apply` comes in a couple of overloads:
 
@@ -446,7 +456,7 @@ The same operations are available in the CLI and Maven-Plugin. The corresponding
 * It will try to resolve URLS to supported migrations and apply them as is, without writing metadata when called with
   one or more URLs as argument. This method can also be ce called through the CLI (via the `run` command).
 * It will apply all refactorings in order when called with one or more instances of `Refactoring`.
-  This method is only available in the Core API. Please read more about it here:  <<applying-refactorings-programmatically>>.
+  This method is only available in the Core API. Please read more about it here: xref:appendix.adoc#applying-refactorings-programmatically[Applying refactorings programmatically].
 
 === Running on the Java module-path
 

--- a/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-catalog</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor-api</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor</artifactId>

--- a/extensions/neo4j-migrations-formats-adoc/pom.xml
+++ b/extensions/neo4j-migrations-formats-adoc/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-csv/pom.xml
+++ b/extensions/neo4j-migrations-formats-csv/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-markdown/pom.xml
+++ b/extensions/neo4j-migrations-formats-markdown/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cli</artifactId>

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/DeleteCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/DeleteCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.cli;
+
+import ac.simons.neo4j.migrations.core.DeleteResult;
+import ac.simons.neo4j.migrations.core.MigrationVersion;
+import ac.simons.neo4j.migrations.core.Migrations;
+import ac.simons.neo4j.migrations.core.MigrationsException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * This command can  be used to delete individual migrations  from the chain of applied migrations.  This is useful when
+ * migration scripts or classes have been deleted.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Antilopen Gang - Anarchie und Alltag
+ * @since TBA
+ */
+@Command(name = "delete", description = "Deletes a migration from the chain of applied migrations")
+public class DeleteCommand extends ConnectedCommand {
+
+	@ParentCommand
+	private MigrationsCli parent;
+
+	@Parameters(paramLabel = "version", description = "The full name of the version or the unique name of the version that should be deleted")
+	private String versionValue;
+
+	@Override
+	public MigrationsCli getParent() {
+		return parent;
+	}
+
+	@Override
+	boolean forceSilence() {
+		return true;
+	}
+
+	@Override
+	Integer withMigrations(Migrations migrations) {
+
+		MigrationVersion version;
+		try {
+			version = MigrationVersion.parse(versionValue);
+		} catch (MigrationsException e) {
+			version = MigrationVersion.withValue(versionValue);
+		}
+
+		DeleteResult result = migrations.delete(version);
+		MigrationsCli.LOGGER.info(result::prettyPrint);
+		result.getWarnings().forEach(MigrationsCli.LOGGER::warning);
+		return 0;
+	}
+}

--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -22,9 +22,10 @@ import ac.simons.neo4j.migrations.core.Migrations;
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
 import ac.simons.neo4j.migrations.core.MigrationsConfig.TransactionMode;
 import ac.simons.neo4j.migrations.core.MigrationsException;
-import picocli.AutoComplete;
+import picocli.AutoComplete.GenerateCompletion;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
@@ -68,7 +69,7 @@ import org.neo4j.driver.Logging;
 	name = "neo4j-migrations",
 	mixinStandardHelpOptions = true,
 	description = "Migrates Neo4j databases.",
-	subcommands = { CleanCommand.class, AutoComplete.GenerateCompletion.class, CommandLine.HelpCommand.class, InfoCommand.class, InitCommand.class, MigrateBTreeIndexesCommand.class, MigrateCommand.class, RunCommand.class, ShowCatalogCommand.class, ValidateCommand.class },
+	subcommands = {CleanCommand.class, DeleteCommand.class, GenerateCompletion.class, HelpCommand.class, InfoCommand.class, InitCommand.class, MigrateBTreeIndexesCommand.class, MigrateCommand.class, RunCommand.class, ShowCatalogCommand.class, ValidateCommand.class},
 	versionProvider = ManifestVersionProvider.class,
 	defaultValueProvider = CommonEnvVarDefaultProvider.class
 )

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations</artifactId>

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DatabaseOperationResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DatabaseOperationResult.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @soundtrack Die Krupps - Paradise Now
  * @since 1.2.0
  */
-public sealed interface DatabaseOperationResult extends OperationResult permits CleanResult, ValidationResult {
+public sealed interface DatabaseOperationResult extends OperationResult permits CleanResult, ValidationResult, DeleteResult {
 
 	/**
 	 * {@return the optional name of the database clean, an empty optional indicates the default database}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DeleteResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DeleteResult.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import java.util.Optional;
+
+/**
+ * A  {@link DeleteResult}  will be  created after  using {@link  Migrations#delete(MigrationVersion)} for  deleting one
+ * single migration. It  contains the number of deleted nodes  and relationships as well as the  number of newly created
+ * relationships.
+ *
+ * @author Michael J. Simons
+ * @since TBA
+ */
+public final class DeleteResult implements DatabaseOperationResult {
+
+	private final String affectedDatabase;
+
+	private final MigrationVersion version;
+
+	private final long nodesDeleted;
+
+	private final long relationshipsDeleted;
+
+	private final long relationshipsCreated;
+
+	DeleteResult(String affectedDatabase, MigrationVersion version, long nodesDeleted, long relationshipsDeleted, long relationshipsCreated) {
+		this.affectedDatabase = affectedDatabase;
+		this.version = version;
+		this.nodesDeleted = nodesDeleted;
+		this.relationshipsDeleted = relationshipsDeleted;
+		this.relationshipsCreated = relationshipsCreated;
+	}
+
+	@Override
+	public Optional<String> getAffectedDatabase() {
+		return Optional.ofNullable(affectedDatabase);
+	}
+
+	/**
+	 * @return {@literal true} if the database has been changed
+	 */
+	public boolean isDatabaseChanged() {
+		return version != null && nodesDeleted > 0;
+	}
+
+	/**
+	 * @return the deleted version (if any)
+	 */
+	public Optional<MigrationVersion> getVersion() {
+		return Optional.ofNullable(version);
+	}
+
+	/**
+	 * @return how many nodes have been deleted.
+	 */
+	public long getNodesDeleted() {
+		return nodesDeleted;
+	}
+
+	/**
+	 * @return how many relationships have been deleted
+	 */
+	public long getRelationshipsDeleted() {
+		return relationshipsDeleted;
+	}
+
+	/**
+	 * @return how many relationships have been created
+	 */
+	public long getRelationshipsCreated() {
+		return relationshipsCreated;
+	}
+
+	@Override
+	public String prettyPrint() {
+
+		if (!isDatabaseChanged()) {
+			return "Database is unchanged, no version has been deleted.";
+		}
+		return String.format(
+			"Migration %s has been removed (deleted %d nodes and %d relationships from %s).",
+			toString(this.version),
+			this.getNodesDeleted(),
+			this.getRelationshipsDeleted(),
+			this.getAffectedDatabase().map(v -> "`" + v + "`").orElse("the default database")
+		);
+	}
+
+	static String toString(MigrationVersion version) {
+
+		return version.getValue()
+			+ version.getOptionalDescription().map(d -> String.format(" (\"%s\")", d)).orElse("");
+	}
+}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
@@ -54,18 +54,34 @@ public final class MigrationVersion {
 		return parse(clazz.getSimpleName());
 	}
 
-	static MigrationVersion parse(String simpleName) {
+	/**
+	 * Creates a {@link MigrationVersion} from the given class or file name
+	 *
+	 * @param name A class or file name
+	 * @return A {@link MigrationVersion}
+	 * @throws MigrationsException if the  name cannot be parsed.  You might check {{@link  #canParse(String)}} prior to
+	 *                             using this method
+	 * @since TBA
+	 */
+	public static MigrationVersion parse(String name) {
 
-		Matcher matcher = VERSION_PATTERN.matcher(simpleName);
+		Matcher matcher = VERSION_PATTERN.matcher(name);
 		if (!matcher.matches()) {
-			throw new MigrationsException("Invalid class name for a migration: " + simpleName);
+			throw new MigrationsException("Invalid class name for a migration: " + name);
 		}
 
 		boolean repeatable = "R".equalsIgnoreCase(matcher.group("type"));
 		return new MigrationVersion(matcher.group("version").replace("_", "."), matcher.group("name").replace("_", " "), repeatable);
 	}
 
-	static MigrationVersion withValue(String value) {
+	/**
+	 * Creates a {@link MigrationVersion} with a given value (the unique version identifier).
+	 *
+	 * @param value The unique version identifier
+	 * @return A {@link MigrationVersion}
+	 * @since TBA
+	 */
+	public static MigrationVersion withValue(String value) {
 
 		return withValue(value, false);
 	}

--- a/neo4j-migrations-core/src/main/resources/ac/simons/neo4j/migrations/core/messages.properties
+++ b/neo4j-migrations-core/src/main/resources/ac/simons/neo4j/migrations/core/messages.properties
@@ -25,5 +25,7 @@ lock_failed = Could not ensure uniqueness of __Neo4jMigrationsLock. Please make 
 errors.edition_mismatch = Migration `{0}` uses a constraint that requires Neo4j Enterprise Edition but the database connected to is a {1} edition, you might want to add a guard like `// assume that edition is enterprise` in your script
 errors.unsupported_extension = Unsupported extension: {0}
 errors.invalid_resource_name = Invalid name `{0}`; the names of resources that should be applied must adhere to well-formed migration versions
+errors.version_required = A valid version must be passed to the delete operation
+errors.incomplete_migrations = More migrations have been applied to the database than locally resolved.
 
 startup_log = {0} connected to {1}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DeleteResultTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DeleteResultTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class DeleteResultTest {
+
+	@Test
+	void shouldCheckMigrationVersion() {
+		var result = new DeleteResult(null, null, 423, 0, 0);
+		assertThat(result.prettyPrint()).isEqualTo(
+			"Database is unchanged, no version has been deleted.");
+	}
+
+	@Test
+	void shouldCheckMigrationNodeCount() {
+		var result = new DeleteResult(null, MigrationVersion.withValue("23"), 0, 0, 0);
+		assertThat(result.prettyPrint()).isEqualTo(
+			"Database is unchanged, no version has been deleted.");
+	}
+
+	@Test
+	void shouldPrettyPrint() {
+		var result = new DeleteResult(null, MigrationVersion.withValue("23"), 42, 0, 0);
+		assertThat(result.prettyPrint()).isEqualTo(
+			"Migration 23 has been removed (deleted 42 nodes and 0 relationships from the default database).");
+	}
+
+	@Test
+	void shouldPrettyPrintFullDescription() {
+		var result = new DeleteResult("x", MigrationVersion.withValueAndDescription("23", "Nichts ist wie es scheint", false), 42, 0, 0);
+		assertThat(result.prettyPrint()).isEqualTo(
+			"Migration 23 (\"Nichts ist wie es scheint\") has been removed (deleted 42 nodes and 0 relationships from `x`).");
+	}
+
+	@Test
+	void shouldBeNullSafe() {
+		var result = new DeleteResult(null, null, 423, 0, 0);
+		assertThat(result.getAffectedDatabase()).isNotPresent();
+		assertThat(result.getVersion()).isNotPresent();
+	}
+}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsTest.java
@@ -16,6 +16,7 @@
 package ac.simons.neo4j.migrations.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +24,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
 
 /**
  * @author Michael J. Simons
@@ -48,5 +50,12 @@ class MigrationsTest {
 
 		Supplier<String> logMessageSupplier = Migrations.logMessageSupplier(callback, LifecyclePhase.BEFORE_CLEAN);
 		assertThat(logMessageSupplier.get()).isEqualTo("Invoked \"Hallo, Welt.\" before clean.");
+	}
+
+	@Test
+	void deletingAVersionShouldRequireAVersion() {
+
+		Migrations migrations = new Migrations(MigrationsConfig.defaultConfig(), mock(Driver.class));
+		assertThatIllegalArgumentException().isThrownBy(() -> migrations.delete(null)).withMessage("A valid version must be passed to the delete operation");
 	}
 }

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb-testharness</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb</artifactId>

--- a/neo4j-migrations-examples/pom.xml
+++ b/neo4j-migrations-examples/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples</artifactId>

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-maven-plugin</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/pom.xml
+++ b/neo4j-migrations-quarkus-parent/deployment/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-deployment</artifactId>

--- a/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
+++ b/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-integration-tests</artifactId>

--- a/neo4j-migrations-quarkus-parent/pom.xml
+++ b/neo4j-migrations-quarkus-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-parent</artifactId>

--- a/neo4j-migrations-quarkus-parent/runtime/pom.xml
+++ b/neo4j-migrations-quarkus-parent/runtime/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-autoconfigure</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>

--- a/neo4j-migrations-test-resources/pom.xml
+++ b/neo4j-migrations-test-resources/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-resources</artifactId>

--- a/neo4j-migrations-test-results/pom.xml
+++ b/neo4j-migrations-test-results/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>2.1.3-SNAPSHOT</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-results</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>eu.michael-simons.neo4j</groupId>
 	<artifactId>neo4j-migrations-parent</artifactId>
-	<version>2.1.3-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Neo4j Migrations</name>
@@ -365,13 +365,6 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<repositories>
-		<repository>
-			<id>mavengems</id>
-			<url>mavengem:http://rubygems.org</url>
-		</repository>
-	</repositories>
 
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
The new `delete` operation provides a safe way of deleting individual migrations from the chain of applied migrations.

See #867.
