### PR TITLE
Adding project diagrams link to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ If you want to be listed here too, please reach out, and we can collaborate to e
 == Manual
 
 The complete manual is available here: https://michael-simons.github.io/neo4j-migrations[michael-simons.github.io/neo4j-migrations].
-The API documentation for the core module is available here: https://michael-simons.github.io/neo4j-migrations/main/site/neo4j-migrations/apidocs/index.html[Neo4j Migrations (Core) {fullVersion} API].
+The API documentation for the core module is available here: https://michael-simons.github.io/neo4j-migrations/main/site/neo4j-migrations/apidocs/index.html[Neo4j Migrations (Core) {fullVersion} API]. The comprehensive set of system diagrams including https://sourcespy.com/github/michaelsimonsneo4jmigrations/[build, module and class diagrams] is automatically generated weekly.
 
 == Presentations and features
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library, dependency and others at (https://sourcespy.com/github/michaelsimonsneo4jmigrations/). Intended to simplify new developer introduction to the project.

In the spirit of transparency - I am the author of the generated diagrams. Hope you find it useful.