### PR TITLE
fix: Check for `!/BOOT-IN/` vs `/!BOOT-INF/`at all relevant places of resource loading.

### DIFF
--- a/extensions/neo4j-migrations-formats-adoc/pom.xml
+++ b/extensions/neo4j-migrations-formats-adoc/pom.xml
@@ -129,7 +129,7 @@
 						</excludes>
 					</artifactSet>
 					<transformers>
-						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 					</transformers>
 					<filters>
 						<filter>

--- a/extensions/neo4j-migrations-formats-adoc/src/main/java/ac/simons/neo4j/migrations/formats/adoc/AsciiDoctorBasedMigrationProvider.java
+++ b/extensions/neo4j-migrations-formats-adoc/src/main/java/ac/simons/neo4j/migrations/formats/adoc/AsciiDoctorBasedMigrationProvider.java
@@ -69,7 +69,7 @@ public final class AsciiDoctorBasedMigrationProvider extends AbstractResourceBas
 		StringBuilder content = new StringBuilder();
 		CharBuffer buffer = CharBuffer.allocate(1024);
 		try (Asciidoctor asciidoctor = Asciidoctor.Factory.create(); BufferedReader in = new BufferedReader(
-			new InputStreamReader(ctx.getUrl().openStream(), Defaults.CYPHER_SCRIPT_ENCODING))) {
+			new InputStreamReader(ctx.openStream(), Defaults.CYPHER_SCRIPT_ENCODING))) {
 			while (in.read(buffer) != -1) {
 				buffer.flip();
 				content.append(buffer);

--- a/extensions/neo4j-migrations-formats-markdown/pom.xml
+++ b/extensions/neo4j-migrations-formats-markdown/pom.xml
@@ -103,7 +103,7 @@
 						</excludes>
 					</artifactSet>
 					<transformers>
-						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 					</transformers>
 					<filters>
 						<filter>

--- a/extensions/neo4j-migrations-formats-markdown/src/main/java/ac/simons/neo4j/migrations/formats/markdown/MarkdownBasedMigrationProvider.java
+++ b/extensions/neo4j-migrations-formats-markdown/src/main/java/ac/simons/neo4j/migrations/formats/markdown/MarkdownBasedMigrationProvider.java
@@ -58,7 +58,7 @@ public final class MarkdownBasedMigrationProvider extends AbstractResourceBasedM
 		StringBuilder content = new StringBuilder();
 		CharBuffer buffer = CharBuffer.allocate(1024);
 		try (BufferedReader in = new BufferedReader(
-			new InputStreamReader(ctx.getUrl().openStream(), Defaults.CYPHER_SCRIPT_ENCODING))) {
+			new InputStreamReader(ctx.openStream(), Defaults.CYPHER_SCRIPT_ENCODING))) {
 			while (in.read(buffer) != -1) {
 				buffer.flip();
 				content.append(buffer);

--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -30,10 +30,10 @@
 	<description>CLI module, packaged as JVM and native assemblies.</description>
 
 	<properties>
-		<assembly-suffix />
+		<assembly-suffix/>
 		<covered-ratio-complexity>0.1</covered-ratio-complexity>
 		<covered-ratio-instructions>0.03</covered-ratio-instructions>
-		<executable-suffix />
+		<executable-suffix/>
 		<java-module-name>ac.simons.neo4j.migrations.cli</java-module-name>
 		<name-of-main-class>ac.simons.neo4j.migrations.cli.MigrationsCli</name-of-main-class>
 		<skipCompress>true</skipCompress>
@@ -118,7 +118,7 @@
 					<reuseForks>false</reuseForks>
 					<environmentVariables>
 						<superSecretSuperPassword>Geheim</superSecretSuperPassword>
-						<emptySecret />
+						<emptySecret/>
 					</environmentVariables>
 					<useModulePath>false</useModulePath>
 				</configuration>
@@ -164,7 +164,7 @@
 							<executable>java</executable>
 							<arguments>
 								<argument>-classpath</argument>
-								<classpath />
+								<classpath/>
 								<argument>${name-of-main-class}</argument>
 								<argument>generate-completion</argument>
 							</arguments>

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
@@ -35,7 +35,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
-import java.net.URL;
 import java.net.URLDecoder;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -203,21 +202,22 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 		}
 	}
 
-	static Migration from(URL url) {
+	static Migration from(ResourceContext context) {
 
+		var url = context.getUrl();
 		String path = URLDecoder.decode(url.getPath(), Defaults.CYPHER_SCRIPT_ENCODING);
 		int lastIndexOf = path.lastIndexOf("/");
 		String fileName = lastIndexOf < 0 ? path : path.substring(lastIndexOf + 1);
 		MigrationVersion version = MigrationVersion.parse(fileName);
 
-		Document document = parseDocument(url);
+		Document document = parseDocument(context);
 		return new CatalogBasedMigration(fileName, version, computeChecksum(document), Catalog.of(document),
 			parseOperations(document, version), getPreconditions(document), isResetCatalog(document));
 	}
 
-	static Document parseDocument(URL url) {
+	static Document parseDocument(ResourceContext context) {
 
-		try (InputStream source = url.openStream()) {
+		try (InputStream source = context.openStream()) {
 			DocumentBuilder documentBuilder = DOCUMENT_BUILDER_FACTORY.get().newDocumentBuilder();
 			documentBuilder.setErrorHandler(new ThrowingErrorHandler());
 			Document document = documentBuilder.parse(source);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedCallback.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedCallback.java
@@ -15,7 +15,6 @@
  */
 package ac.simons.neo4j.migrations.core;
 
-import java.net.URL;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
@@ -41,9 +40,9 @@ final class CypherBasedCallback implements Callback {
 
 	private final String description;
 
-	CypherBasedCallback(URL url, boolean autocrlf) {
+	CypherBasedCallback(ResourceContext context) {
 
-		this.cypherResource = CypherResource.of(url, autocrlf);
+		this.cypherResource = CypherResource.of(context);
 
 		String script = this.cypherResource.getIdentifier();
 		Matcher matcher = LifecyclePhase.LIFECYCLE_PATTERN.matcher(script);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedMigration.java
@@ -17,7 +17,6 @@ package ac.simons.neo4j.migrations.core;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,12 +41,8 @@ final class CypherBasedMigration extends AbstractCypherBasedMigration implements
 	@SuppressWarnings("squid:S3077") // This will always be an immutable instance.s
 	private volatile Optional<String> checksumOfNonePreconditions;
 
-	CypherBasedMigration(URL url) {
-		this(url, Defaults.AUTOCRLF);
-	}
-
-	CypherBasedMigration(URL url, boolean autocrlf) {
-		super(CypherResource.of(url, autocrlf));
+	CypherBasedMigration(ResourceContext context) {
+		super(CypherResource.of(context));
 	}
 
 	// The whole point of the optional is in fact to deal with non-null

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResourceBasedMigrationProvider.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResourceBasedMigrationProvider.java
@@ -34,7 +34,7 @@ public final class CypherResourceBasedMigrationProvider implements ResourceBased
 
 	@Override
 	public Collection<Migration> handle(ResourceContext ctx) {
-		return Collections.singletonList(new CypherBasedMigration(ctx.getUrl(), ctx.getConfig().isAutocrlf()));
+		return Collections.singletonList(new CypherBasedMigration(ctx));
 	}
 
 	@Override

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCatalogBasedMigrationProvider.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCatalogBasedMigrationProvider.java
@@ -39,6 +39,6 @@ public final class DefaultCatalogBasedMigrationProvider implements ResourceBased
 	@Override
 	public Collection<Migration> handle(ResourceContext ctx) {
 
-		return Collections.singletonList(CatalogBasedMigration.from(ctx.getUrl()));
+		return Collections.singletonList(CatalogBasedMigration.from(ctx));
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
@@ -200,7 +200,7 @@ final class DefaultCypherResource implements CypherResource {
 					handleUseStatement(newStatements, useMatcher, finalStatement);
 				}
 				useMatcher.appendTail(finalStatement);
-				if (finalStatement.length() != 0) {
+				if (!finalStatement.isEmpty()) {
 					newStatements.add(finalStatement.toString());
 				}
 			}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ResourceDiscoverer.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
 /**
- * Abstract base class for implementing discoverer discovering resources.
+ * Factory providing different {@link Discoverer} implementations.
  *
  * @author Michael J. Simons
  * @param <T> The concrete type to be instantiated with a discovered resource
@@ -75,7 +75,7 @@ final class ResourceDiscoverer<T> implements Discoverer<T> {
 				return lastDotIdx > lastSlashIdx && fullPath.substring(lastDotIdx + 1).equalsIgnoreCase(Defaults.CYPHER_SCRIPT_EXTENSION);
 		});
 		return new ResourceDiscoverer<>(resourceScanner, filter,
-			ctx -> Collections.singletonList(new CypherBasedCallback(ctx.getUrl(), ctx.getConfig().isAutocrlf())));
+			ctx -> Collections.singletonList(new CypherBasedCallback(ctx)));
 	}
 
 	private static final Logger LOGGER = Logger.getLogger(ResourceDiscoverer.class.getName());

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/AddSurrogateKeyIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/AddSurrogateKeyIT.java
@@ -38,7 +38,7 @@ class AddSurrogateKeyIT extends AbstractRefactoringsITTestBase {
 
 		try (Session session = driver.session()) {
 			session.run("MATCH (n) DETACH DELETE n").consume();
-			CypherResource.of(AddSurrogateKeyIT.class.getResource("/moviegraph/movies.cypher")).getExecutableStatements()
+			CypherResource.of(ResourceContext.of(AddSurrogateKeyIT.class.getResource("/moviegraph/movies.cypher"))).getExecutableStatements()
 				.forEach(session::run);
 		}
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CatalogBasedMigrationTest.java
@@ -98,7 +98,7 @@ class CatalogBasedMigrationTest {
 	void checksumShouldBeCorrect(String in) {
 		URL url = TestResources.class.getResource("/catalogbased/identical-migrations/V01__" + in);
 		Objects.requireNonNull(url);
-		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(url);
+		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(ResourceContext.of(url));
 		assertThat(schemaBasedMigration.getChecksum()).hasValue("2210671299");
 		assertThat(schemaBasedMigration.getCatalog().getItems()).hasSize(2);
 	}
@@ -107,7 +107,7 @@ class CatalogBasedMigrationTest {
 	void shouldParsePreconditions1() {
 		URL url = TestResources.class.getResource("/catalogbased/identical-migrations/V01__01.xml");
 		Objects.requireNonNull(url);
-		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(url);
+		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(ResourceContext.of(url));
 		assertThat(schemaBasedMigration.getPreconditions()).hasSize(2);
 		assertThat(schemaBasedMigration.getPreconditions()).map(Precondition::getType)
 			.containsExactlyInAnyOrder(Precondition.Type.ASSERTION, Precondition.Type.ASSUMPTION);
@@ -120,7 +120,7 @@ class CatalogBasedMigrationTest {
 
 		URL url = Objects.requireNonNull(TestResources.class.getResource("/catalogbased/identical-migrations/V01__01.xml"));
 
-		Migration migration = CatalogBasedMigration.from(url);
+		Migration migration = CatalogBasedMigration.from(ResourceContext.of(url));
 		assertThat(migration.getOptionalDescription()).hasValue("01");
 	}
 
@@ -128,7 +128,7 @@ class CatalogBasedMigrationTest {
 	void shouldParsePreconditions2() {
 		URL url = TestResources.class.getResource("/preconditions/V0002__Create_node_keys.xml");
 		Objects.requireNonNull(url);
-		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(url);
+		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(ResourceContext.of(url));
 		assertThat(schemaBasedMigration.isResetCatalog()).isFalse();
 		assertThat(schemaBasedMigration.getPreconditions()).hasSize(1);
 		assertThat(schemaBasedMigration.getPreconditions()).singleElement()
@@ -144,7 +144,7 @@ class CatalogBasedMigrationTest {
 	void shouldParseReset() {
 		URL url = TestResources.class.getResource("/catalogbased/parsing/V01__with_reset.xml");
 		Objects.requireNonNull(url);
-		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(url);
+		CatalogBasedMigration schemaBasedMigration = (CatalogBasedMigration) CatalogBasedMigration.from(ResourceContext.of(url));
 		assertThat(schemaBasedMigration.isResetCatalog()).isTrue();
 	}
 
@@ -214,7 +214,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/full-example.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			assertThat(CatalogBasedMigration.parseOperations(document, MigrationVersion.baseline()))
 				.filteredOn(op -> op instanceof DefaultRefactorOperation)
 				.map(DefaultRefactorOperation.class::cast)
@@ -375,7 +375,7 @@ class CatalogBasedMigrationTest {
 		void emptyDocumentShouldBeReadable() {
 			URL url = TestResources.class.getResource("/catalogbased/parsing/no-operations.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			assertThat(CatalogBasedMigration.parseOperations(document, MigrationVersion.withValue("1"))).isEmpty();
 		}
 
@@ -384,7 +384,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/apply.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			List<Operation> operations = CatalogBasedMigration.parseOperations(document,
 				MigrationVersion.withValue("1"));
 			assertThat(operations).hasSize(1)
@@ -396,7 +396,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/verify-default.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			List<Operation> operations = CatalogBasedMigration.parseOperations(document,
 				MigrationVersion.withValue("1"));
 			assertThat(operations).hasSize(1)
@@ -415,7 +415,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/verify-modified.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			List<Operation> operations = CatalogBasedMigration.parseOperations(document,
 				MigrationVersion.withValue("1"));
 			assertThat(operations).hasSize(1)
@@ -443,7 +443,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/" + file);
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			List<Operation> operations = CatalogBasedMigration.parseOperations(document,
 				MigrationVersion.withValue("1"));
 			assertThat(operations).hasSize(4)
@@ -482,7 +482,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/" + file + "-both-ref-and-item.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			MigrationVersion version = MigrationVersion.withValue("1");
 			assertThatIllegalArgumentException()
 				.isThrownBy(() -> CatalogBasedMigration.parseOperations(document, version))
@@ -496,7 +496,7 @@ class CatalogBasedMigrationTest {
 
 			URL url = TestResources.class.getResource("/catalogbased/parsing/" + file + "-both-item-and-local.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 			MigrationVersion version = MigrationVersion.withValue("1");
 			assertThatIllegalArgumentException()
 				.isThrownBy(() -> CatalogBasedMigration.parseOperations(document, version))
@@ -872,7 +872,7 @@ class CatalogBasedMigrationTest {
 		void optionsShouldBeApply() {
 			URL url = TestResources.class.getResource("/catalogbased/actual-migrations-with-complete-verification/V20__Apply_complete_catalog.xml");
 			Objects.requireNonNull(url);
-			Document document = CatalogBasedMigration.parseDocument(url);
+			Document document = CatalogBasedMigration.parseDocument(ResourceContext.of(url));
 
 			List<Operation> operations = CatalogBasedMigration.parseOperations(document,
 				MigrationVersion.baseline());

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ChainBuilderTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ChainBuilderTest.java
@@ -33,7 +33,7 @@ class ChainBuilderTest {
 	void shouldMatch() {
 
 		CypherBasedMigration cypherBasedMigration = new CypherBasedMigration(
-			TestResources.class.getResource("/my/awesome/migrations/V021__Die halbe Wahrheit.cypher"));
+			ResourceContext.of(TestResources.class.getResource("/my/awesome/migrations/V021__Die halbe Wahrheit.cypher")));
 		cypherBasedMigration.setAlternativeChecksums(Collections.singletonList("foobar"));
 
 		assertThat(ChainBuilder.matches(Optional.of("200310393"), cypherBasedMigration)).isTrue();

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CypherBasedCallbackTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CypherBasedCallbackTest.java
@@ -36,7 +36,7 @@ class CypherBasedCallbackTest {
 		@Test
 		void emptyDescriptionShouldBeHandled() throws MalformedURLException {
 
-			CypherBasedCallback callback = new CypherBasedCallback(new URL("file:./afterMigrate.cypher"), false);
+			CypherBasedCallback callback = new CypherBasedCallback(ResourceContext.of(new URL("file:./afterMigrate.cypher")));
 			assertThat(callback.getOptionalDescription()).isEmpty();
 		}
 
@@ -45,7 +45,7 @@ class CypherBasedCallbackTest {
 
 			URL url = new URL("file:./afterMigrate__.cypher");
 			assertThatExceptionOfType(MigrationsException.class)
-				.isThrownBy(() -> new CypherBasedCallback(url, false))
+				.isThrownBy(() -> new CypherBasedCallback(ResourceContext.of(url)))
 				.withMessage("Invalid name for a callback script: afterMigrate__.cypher");
 		}
 
@@ -53,7 +53,7 @@ class CypherBasedCallbackTest {
 		void shouldReplaceUnderScores() throws MalformedURLException {
 
 			CypherBasedCallback callback = new CypherBasedCallback(
-				new URL("file:./afterMigrate__insert some_description here.cypher"), false);
+				ResourceContext.of(new URL("file:./afterMigrate__insert some_description here.cypher")));
 			assertThat(callback.getOptionalDescription()).hasValue("insert some description here");
 		}
 	}

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CypherResourceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/CypherResourceTest.java
@@ -56,7 +56,7 @@ class CypherResourceTest {
 		when(url.openStream()).thenThrow(cause);
 		when(url.getPath()).thenReturn("a.cypher");
 
-		CypherResource resource = CypherResource.of(url);
+		CypherResource resource = CypherResource.of(ResourceContext.of(url));
 
 		assertThatExceptionOfType(UncheckedIOException.class)
 			.isThrownBy(resource::getExecutableStatements)
@@ -72,7 +72,7 @@ class CypherResourceTest {
 		when(url.toString()).thenReturn("jar:file:/target/UberjarWithNestedJar.jar!/BOOT-INF/classes/neo4j/migrations/V010__Test.cypher");
 		when(url.getPath()).thenReturn("V010__Test.cypher");
 
-		CypherResource resource = CypherResource.of(url);
+		CypherResource resource = CypherResource.of(ResourceContext.of(url));
 
 		assertThatExceptionOfType(UncheckedIOException.class)
 			.isThrownBy(resource::getExecutableStatements)

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
@@ -39,7 +39,7 @@ class DefaultCypherResourceTest {
 	@ValueSource(strings = { "multiline_no_comments", "singleline_no_comments" })
 	void shouldGetAllStatements(String r) {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/" + r + ".cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/" + r + ".cypher")));
 
 		assertThat(cypherResource.getStatements()).hasSize(3);
 		assertThat(cypherResource.getSingleLineComments()).isEmpty();
@@ -52,7 +52,7 @@ class DefaultCypherResourceTest {
 		"comments_following_each_other1", "comments_following_each_other2" })
 	void shouldGetAllStatementsAndComments(String r) {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/" + r + ".cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/" + r + ".cypher")));
 
 		assertThat(cypherResource.getStatements()).hasSize(4);
 		assertThat(cypherResource.getExecutableStatements()).hasSize(3);
@@ -69,7 +69,7 @@ class DefaultCypherResourceTest {
 	@Test
 	void onlyCommentsShouldBeTreatedAsSuch() {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/onlycomments.cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/onlycomments.cypher")));
 
 		assertThat(cypherResource.getStatements()).hasSize(1);
 		assertThat(cypherResource.getExecutableStatements()).isEmpty();
@@ -79,7 +79,7 @@ class DefaultCypherResourceTest {
 	@Test
 	void onlyCommentsShouldBeTreatedAsSuch2() {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/multiple_comments_one_command.cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/multiple_comments_one_command.cypher")));
 
 		assertThat(cypherResource.getStatements()).hasSize(1);
 		assertThat(cypherResource.getExecutableStatements()).containsExactly(
@@ -93,7 +93,7 @@ class DefaultCypherResourceTest {
 	@Test
 	void singleLineFollowingEachOther() {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			TestResources.class.getResource("/preconditions/44/V0001__Create_existence_constraint.cypher"));
+			ResourceContext.of(TestResources.class.getResource("/preconditions/44/V0001__Create_existence_constraint.cypher")));
 		assertThat(cypherResource.getStatements()).hasSize(1);
 		assertThat(cypherResource.getSingleLineComments()).hasSize(3);
 		List<Precondition> preconditions = Precondition.in(cypherResource);
@@ -104,7 +104,7 @@ class DefaultCypherResourceTest {
 	void shouldRetrievePreconditions() {
 
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/several_preconditions.cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/several_preconditions.cypher")));
 		List<Precondition> preconditions = Precondition.in(cypherResource);
 		assertThat(preconditions)
 			.hasSize(3)
@@ -131,7 +131,7 @@ class DefaultCypherResourceTest {
 
 		URL resource = DefaultCypherResourceTest.class.getResource("/V0001__" + type + ".cypher");
 
-		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(resource);
+		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(ResourceContext.of(resource));
 		List<String> statements = cypherResource.getStatements();
 
 		assertThat(statements).hasSize(3).containsOnly("MATCH (n) RETURN count(n) AS n");
@@ -144,7 +144,7 @@ class DefaultCypherResourceTest {
 
 		URL resource = TestResources.class.getResource("/ml/" + type + "/V0001__Just a couple of matches.cypher");
 
-		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(resource, true);
+		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(ResourceContext.of(resource, MigrationsConfig.builder().withAutocrlf(true).build()));
 		List<String> statements = cypherResource.getStatements();
 
 		assertThat(statements).hasSize(3).containsOnly("MATCH (n)\nRETURN count(n) AS n");
@@ -156,7 +156,7 @@ class DefaultCypherResourceTest {
 
 		// Those are in eu.michael-simons.neo4j.neo4j-migrations:test-migrations
 		URL resource = TestResources.class.getResource("/some/changeset/V0002__create_new_data.cypher");
-		DefaultCypherResource migration = (DefaultCypherResource) CypherResource.of(resource);
+		DefaultCypherResource migration = (DefaultCypherResource) CypherResource.of(ResourceContext.of(resource));
 
 		List<String> statements = migration.getStatements();
 		assertThat(statements).containsExactly("CREATE (n:FixedData) RETURN n", "MATCH (n) RETURN count(n) AS foobar");
@@ -166,7 +166,7 @@ class DefaultCypherResourceTest {
 	void shouldHandleMultilineStatements() {
 
 		URL resource = TestResources.class.getResource("/my/awesome/migrations/moreStuff/V007__BondTheNameIsBond.cypher");
-		DefaultCypherResource migration = (DefaultCypherResource) CypherResource.of(resource);
+		DefaultCypherResource migration = (DefaultCypherResource) CypherResource.of(ResourceContext.of(resource));
 		List<String> statements = migration.getStatements();
 		assertThat(statements).hasSize(2);
 	}
@@ -176,7 +176,7 @@ class DefaultCypherResourceTest {
 
 		URL resource = TestResources.class.getResource("/some/changeset/V0001__delete_old_data.cypher");
 
-		CypherBasedMigration migration = new CypherBasedMigration(resource);
+		CypherBasedMigration migration = new CypherBasedMigration(ResourceContext.of(resource));
 
 		assertThat(migration.getChecksum()).hasValue("1100083332");
 	}
@@ -186,19 +186,19 @@ class DefaultCypherResourceTest {
 
 		URL script1 = DefaultCypherResourceTest.class.getResource("/parsing/V01__without_assumption.cypher");
 
-		DefaultCypherResource cypherResource1 = (DefaultCypherResource) CypherResource.of(script1, false);
+		DefaultCypherResource cypherResource1 = (DefaultCypherResource) CypherResource.of(ResourceContext.of(script1));
 		assertThat(cypherResource1.getChecksum()).isEqualTo("1995107586");
 
-		CypherBasedMigration migrationWithoutAssumptions = new CypherBasedMigration(script1);
+		CypherBasedMigration migrationWithoutAssumptions = new CypherBasedMigration(ResourceContext.of(script1));
 		assertThat(migrationWithoutAssumptions.getChecksum()).hasValue("1995107586");
 		assertThat(migrationWithoutAssumptions.getAlternativeChecksums()).isEmpty();
 
 		URL script2 = DefaultCypherResourceTest.class.getResource("/parsing/V01__with_assumption.cypher");
 
-		DefaultCypherResource cypherResource2 = (DefaultCypherResource) CypherResource.of(script2, false);
+		DefaultCypherResource cypherResource2 = (DefaultCypherResource) CypherResource.of(ResourceContext.of(script2));
 		assertThat(cypherResource2.getChecksum()).isEqualTo("2044432884");
 
-		CypherBasedMigration migrationWithAssumptions = new CypherBasedMigration(script2);
+		CypherBasedMigration migrationWithAssumptions = new CypherBasedMigration(ResourceContext.of(script2));
 		assertThat(migrationWithAssumptions.getChecksum()).hasValue("2044432884");
 		assertThat(migrationWithAssumptions.getAlternativeChecksums()).contains("1995107586");
 	}
@@ -209,7 +209,7 @@ class DefaultCypherResourceTest {
 
 		URL url = DefaultCypherResourceTest.class.getResource("/parsing/V01__without_assumption.cypher");
 
-		Migration migration = new CypherBasedMigration(url);
+		Migration migration = new CypherBasedMigration(ResourceContext.of(url));
 		assertThat(migration.getOptionalDescription()).hasValue("without assumption");
 	}
 
@@ -218,10 +218,10 @@ class DefaultCypherResourceTest {
 
 		URL script1 = DefaultCypherResourceTest.class.getResource("/parsing/V01__with_random_comments.cypher");
 
-		DefaultCypherResource cypherResource1 = (DefaultCypherResource) CypherResource.of(script1, false);
+		DefaultCypherResource cypherResource1 = (DefaultCypherResource) CypherResource.of(ResourceContext.of(script1));
 		assertThat(cypherResource1.getChecksum()).isNotEqualTo("2104077345");
 
-		CypherBasedMigration migrationWithoutAssumptions = new CypherBasedMigration(script1);
+		CypherBasedMigration migrationWithoutAssumptions = new CypherBasedMigration(ResourceContext.of(script1));
 		assertThat(migrationWithoutAssumptions.getChecksum()).hasValueSatisfying(v -> assertThat(v).isNotEqualTo("2104077345"));
 		assertThat(migrationWithoutAssumptions.getAlternativeChecksums()).isEmpty();
 	}
@@ -258,7 +258,7 @@ class DefaultCypherResourceTest {
 	@Test
 	void shouldHandleUseStatements() {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/with_use_statements.cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/with_use_statements.cypher")));
 
 		assertThat(cypherResource.getExecutableStatements()).containsExactly(
 			"MATCH (n) RETURN count(n)",
@@ -304,7 +304,7 @@ class DefaultCypherResourceTest {
 	@Test
 	void shouldDetectWrongUseStatements() {
 		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(
-			DefaultCypherResourceTest.class.getResource("/parsing/with_use_statements_wrong.cypher"));
+			ResourceContext.of(DefaultCypherResourceTest.class.getResource("/parsing/with_use_statements_wrong.cypher")));
 
 		assertThatExceptionOfType(MigrationsException.class)
 			.isThrownBy(cypherResource::getExecutableStatements)

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/NormalizeIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/NormalizeIT.java
@@ -43,7 +43,7 @@ class NormalizeIT extends AbstractRefactoringsITTestBase {
 
 		try (Session session = driver.session()) {
 			session.run("MATCH (n) DETACH DELETE n").consume();
-			CypherResource.of(RenameIT.class.getResource("/moviegraph/movies.cypher")).getExecutableStatements()
+			CypherResource.of(ResourceContext.of(RenameIT.class.getResource("/moviegraph/movies.cypher"))).getExecutableStatements()
 				.forEach(session::run);
 			session.run("MATCH (n:Movie {title:'The Matrix'}) SET n.watched = 'ja'").consume();
 			session.run("MATCH (n:Movie {title:'The Matrix Reloaded'}) SET n.watched = 'n'").consume();

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/RenameIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/RenameIT.java
@@ -43,7 +43,7 @@ class RenameIT extends AbstractRefactoringsITTestBase {
 
 		try (Session session = driver.session()) {
 			session.run("MATCH (n) DETACH DELETE n").consume();
-			CypherResource.of(RenameIT.class.getResource("/moviegraph/movies.cypher")).getExecutableStatements()
+			CypherResource.of(ResourceContext.of(RenameIT.class.getResource("/moviegraph/movies.cypher"))).getExecutableStatements()
 				.forEach(session::run);
 		}
 	}

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -163,7 +163,7 @@
 				<configuration>
 					<skip>true</skip>
 				</configuration>
-				<reportSets />
+				<reportSets/>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -202,7 +202,7 @@
 				<configuration>
 					<skip>true</skip>
 				</configuration>
-				<reportSets />
+				<reportSets/>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/src/test/java/ac/simons/neo4j/migrations/examples/sb/ApplicationIT.java
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/src/test/java/ac/simons/neo4j/migrations/examples/sb/ApplicationIT.java
@@ -78,6 +78,9 @@ class ApplicationIT {
 			}
 		}
 
+		p.destroy();
+		assertThat(p.exitValue()).isZero();
+
 		try (Driver driver = GraphDatabase.driver(neo4j.getBoltUrl(), AuthTokens.basic("neo4j", neo4j.getAdminPassword()),
 			Config.builder().withLogging(Logging.console(Level.OFF)).build());
 			Session session = driver.session()
@@ -87,6 +90,7 @@ class ApplicationIT {
 
 			Migrations migrations = new Migrations(MigrationsConfig.defaultConfig(), driver);
 			MigrationChain info = migrations.info(MigrationChain.ChainBuilderMode.REMOTE);
+			assertThat(info.length()).isEqualTo(4);
 			assertThat(info.getLastAppliedVersion().map(MigrationVersion::getValue)).hasValue("030");
 			assertThat(info.isApplied("030")).isTrue();
 		}

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -330,7 +330,7 @@
 				<configuration>
 					<skip>true</skip>
 				</configuration>
-				<reportSets />
+				<reportSets/>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/neo4j-migrations-test-resources/src/main/resources/sb/V025__SomeConstraints.xml
+++ b/neo4j-migrations-test-resources/src/main/resources/sb/V025__SomeConstraints.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<migration xmlns="https://michael-simons.github.io/neo4j-migrations">
+	<create>
+		<constraint name="unique_isbn" type="unique">
+			<label>Book</label>
+			<properties>
+				<property>isbn</property>
+			</properties>
+		</constraint>
+	</create>
+</migration>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<guava.version>33.0.0-jre</guava.version>
 		<jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
 		<japicmp-maven-plugin.version>0.19.1</japicmp-maven-plugin.version>
-		<java-module-name />
+		<java-module-name/>
 		<java.version>17</java.version>
 		<!-- to be overridden in sub modules -->
 		<junit.jupiter.version>5.10.2</junit.jupiter.version>
@@ -788,7 +788,7 @@
 								<requireJavaVersion>
 									<version>21</version>
 								</requireJavaVersion>
-								<DependencyConvergence />
+								<DependencyConvergence/>
 								<requireMavenVersion>
 									<version>${maven.version}</version>
 								</requireMavenVersion>
@@ -923,9 +923,9 @@
 					<attributes>
 						<icons>font</icons>
 						<toc>left</toc>
-						<setanchors />
-						<idprefix />
-						<idseparator />
+						<setanchors/>
+						<idprefix/>
+						<idseparator/>
 						<imagesdir>${docsImagesDir}</imagesdir>
 						<neo4j-java-driver-version>${neo4j-java-driver.version}</neo4j-java-driver-version>
 						<neo4j-migrations.version>${project.version}</neo4j-migrations.version>


### PR DESCRIPTION
The `ResourceContext` now has a centralised way of getting an `InputStream` for resources and checks if it runs on a Spring Boot > 3.2.0 modern nested Jar.
The factory methods for the Cypher resources that take a raw URL have been deprecated and will be removed in 3.x.
All other factory methods of resources have been internal anyway.

Fixes #1248.
