### PR TITLE
Quarkus config mapping migration

### DIFF
--- a/neo4j-migrations-quarkus-parent/deployment/src/main/java/ac/simons/neo4j/migrations/quarkus/deployment/MigrationsDevConsoleProcessor.java
+++ b/neo4j-migrations-quarkus-parent/deployment/src/main/java/ac/simons/neo4j/migrations/quarkus/deployment/MigrationsDevConsoleProcessor.java
@@ -23,6 +23,8 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
 /**
+ * Provides the necessary RPC items to fill toe web-ui, including the corresponding cards.
+ *
  * @author Michael J. Simons
  * @soundtrack Dr. Dre - The Chronic
  * @since 1.4.0

--- a/neo4j-migrations-quarkus-parent/deployment/src/main/java/ac/simons/neo4j/migrations/quarkus/deployment/MigrationsProcessor.java
+++ b/neo4j-migrations-quarkus-parent/deployment/src/main/java/ac/simons/neo4j/migrations/quarkus/deployment/MigrationsProcessor.java
@@ -101,7 +101,7 @@ public class MigrationsProcessor {
 	@SuppressWarnings("unused")
 	DiscovererBuildItem createDiscoverer(CombinedIndexBuildItem combinedIndexBuildItem, MigrationsBuildTimeProperties buildTimeProperties) {
 
-		var packagesToScan = buildTimeProperties.packagesToScan.orElseGet(List::of);
+		var packagesToScan = buildTimeProperties.packagesToScan().orElseGet(List::of);
 		var classesFoundDuringBuild = findClassBasedMigrations(packagesToScan, combinedIndexBuildItem.getIndex());
 		return new DiscovererBuildItem(StaticJavaBasedMigrationDiscoverer.of(classesFoundDuringBuild));
 	}
@@ -183,7 +183,7 @@ public class MigrationsProcessor {
 	ClasspathResourceScannerBuildItem createScanner(MigrationsBuildTimeProperties buildTimeProperties) throws IOException {
 
 		var providers = ResourceBasedMigrationProvider.unique();
-		var resourcesFoundDuringBuild = findResourceBasedMigrations(providers, buildTimeProperties.locationsToScan);
+		var resourcesFoundDuringBuild = findResourceBasedMigrations(providers, buildTimeProperties.locationsToScan());
 		return new ClasspathResourceScannerBuildItem(StaticClasspathResourceScanner.of(resourcesFoundDuringBuild));
 	}
 

--- a/neo4j-migrations-quarkus-parent/integration-tests/src/main/java/ac/simons/neo4j/migrations/quarkus/it/MigrationsResource.java
+++ b/neo4j-migrations-quarkus-parent/integration-tests/src/main/java/ac/simons/neo4j/migrations/quarkus/it/MigrationsResource.java
@@ -38,7 +38,7 @@ public class MigrationsResource {
 	Migrations migrations;
 
 	/**
-	 * @return The list of migrations given by the info command.
+	 * {@return The list of migrations given by the info command}
 	 */
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
@@ -20,7 +20,6 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,15 +36,17 @@ import java.util.Optional;
 public interface MigrationsBuildTimeProperties {
 
 	/**
-	 * List of packages to scan for Java migrations. This is a build time configuration option and can't be changed during runtime.
+	 * This is a build time configuration option and can't be changed during runtime.
+	 *
+	 * @return the list of packages to scan for Java migrations.
 	 */
-	@WithName("packages-to-scan")
 	Optional<List<String>> packagesToScan();
 
 	/**
-	 * Locations of migrations scripts. This is a build time configuration option and can't be changed during runtime.
+	 * This is a build time configuration option and can't be changed during runtime.
+	 *
+	 * @return the list of locations of migrations scripts
 	 */
 	@WithDefault(Defaults.LOCATIONS_TO_SCAN_VALUE)
-	@WithName("locations-to-scan")
 	List<String> locationsToScan();
 }

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
@@ -16,9 +16,10 @@
 package ac.simons.neo4j.migrations.quarkus.runtime;
 
 import ac.simons.neo4j.migrations.core.Defaults;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,18 +31,18 @@ import java.util.Optional;
  * @soundtrack Bad Religion - The Gray Race
  * @since 1.3.0
  */
-@ConfigRoot(prefix = "org.neo4j", name = "migrations", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class MigrationsBuildTimeProperties {
+@ConfigMapping(prefix = "org.neo4j.migrations")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface MigrationsBuildTimeProperties {
 
 	/**
 	 * List of packages to scan for Java migrations. This is a build time configuration option and can't be changed during runtime.
 	 */
-	@ConfigItem
-	public Optional<List<String>> packagesToScan;
+	Optional<List<String>> packagesToScan();
 
 	/**
 	 * Locations of migrations scripts. This is a build time configuration option and can't be changed during runtime.
 	 */
-	@ConfigItem(defaultValue = Defaults.LOCATIONS_TO_SCAN_VALUE)
-	public List<String> locationsToScan;
+	@WithDefault(Defaults.LOCATIONS_TO_SCAN_VALUE)
+	List<String> locationsToScan();
 }

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsBuildTimeProperties.java
@@ -20,6 +20,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,11 +39,13 @@ public interface MigrationsBuildTimeProperties {
 	/**
 	 * List of packages to scan for Java migrations. This is a build time configuration option and can't be changed during runtime.
 	 */
+	@WithName("packages-to-scan")
 	Optional<List<String>> packagesToScan();
 
 	/**
 	 * Locations of migrations scripts. This is a build time configuration option and can't be changed during runtime.
 	 */
 	@WithDefault(Defaults.LOCATIONS_TO_SCAN_VALUE)
+	@WithName("locations-to-scan")
 	List<String> locationsToScan();
 }

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsConfigCustomizer.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsConfigCustomizer.java
@@ -13,27 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ac.simons.neo4j.migrations.quarkus.it.migrations;
+package ac.simons.neo4j.migrations.quarkus.runtime;
 
-import ac.simons.neo4j.migrations.core.JavaBasedMigration;
-import ac.simons.neo4j.migrations.core.MigrationContext;
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
 /**
- * A placeholder class for a package private inner class that should be discovered.
+ * Config customizer to ignore validation of unmapped properties between build-time and runtime.
  *
  * @author Michael J. Simons
+ * @author Roberto Cortez
+ * @see MigrationsProperties
+ * @see MigrationsBuildTimeProperties
  */
-public class SomeService {
+@StaticInitSafe
+public final class MigrationsConfigCustomizer implements SmallRyeConfigBuilderCustomizer {
 
-	private SomeService() {
-	}
-
-	@SuppressWarnings({ "squid:S101", "unused" })
-	static class V0003__SomethingStatic implements JavaBasedMigration {
-
-		@Override
-		public void apply(MigrationContext context) {
-			// Left empty in purpose
-		}
+	@Override
+	public void configBuilder(final SmallRyeConfigBuilder builder) {
+		builder.withMappingIgnore("org.neo4j.migrations.**");
 	}
 }

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
@@ -22,7 +22,6 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
 
 import java.time.Duration;
 import java.util.List;
@@ -42,45 +41,49 @@ public interface MigrationsProperties {
 	 * An optional list of external locations that don't become part of the image. Those locations can be changed during
 	 * runtime in contrast to {@link MigrationsBuildTimeProperties#locationsToScan} but can only be used for locations
 	 * inside the filesystem.
+	 * @return the external locations to scan
 	 */
 	Optional<List<String>> externalLocations();
 
 	/**
 	 * Set to {@literal false} to disable migrations at start. An instance of {@link ac.simons.neo4j.migrations.core.Migrations} will
 	 * still be provided to interested parties.
+	 * @return whether migrations are enabled or not
 	 */
 	@WithDefault("true")
 	boolean enabled();
 
 	/**
-	 * The transaction mode in use (Defaults to "per migration", meaning one script is run in one transaction).
+	 * {@return the transaction mode in use (Defaults to "per migration", meaning one script is run in one transaction)}
 	 */
 	@WithDefault(Defaults.TRANSACTION_MODE_VALUE)
 	MigrationsConfig.TransactionMode transactionMode();
 
 	/**
-	 * The database that should be migrated (Neo4j EE 4.0+ only). Leave empty for using the default database.
+	 * {@return the database that should be migrated (Neo4j EE 4.0+ only), leave empty for using the default database}
 	 */
 	Optional<String> database();
 
 	/**
-	 * The database that should be used for storing informations about migrations (Neo4j EE 4.0+ only). Leave empty for using the default database.
+	 * {@return the database that should be used for storing informations about migrations (Neo4j EE 4.0+ only), leave empty for using the default database}
 	 */
 	Optional<String> schemaDatabase();
 
 	/**
 	 * An alternative user to impersonate during migration. Might have higher privileges than the user connected, which
 	 * will be dropped again after migration. Requires Neo4j EE 4.4+. Leave empty for using the connected user.
+	 * @return the name of the user to impersonate
 	 */
 	Optional<String> impersonatedUser();
 
 	/**
-	 * Username recorded as property {@literal by} on the MIGRATED_TO relationship.
+	 * {@return username recorded as property {@literal by} on the MIGRATED_TO relationship}
 	 */
 	Optional<String> installedBy();
 
 	/**
 	 * Validating helps you verify that the migrations applied to the database match the ones available locally and is on by default.
+	 * @return a flag whether to validate the migration chaon during startup
 	 */
 	@WithDefault(Defaults.VALIDATE_ON_MIGRATE_VALUE)
 	boolean validateOnMigrate();
@@ -93,17 +96,18 @@ public interface MigrationsProperties {
 	 * existing LF-style line endings with CRLF, or insert both line-ending characters when the user hits the enter key.
 	 * Neo4j migrations can handle this by auto-converting CRLF line endings into LF before computing checksums of a
 	 * Cypher-based migration or applying it.
+	 * @return a flag whether to use automatic CRLF detection
 	 */
 	@WithDefault(Defaults.AUTOCRLF_VALUE)
 	boolean autocrlf();
 
 	/**
-	 * A configurable delay that will be applied in between applying two migrations.
+	 * {@return a configurable delay that will be applied in between applying two migrations}
 	 */
 	Optional<Duration> delayBetweenMigrations();
 
 	/**
-	 * The sort order for migrations. Defaults to {@link VersionSortOrder#LEXICOGRAPHIC} until 3.x.
+	 * {@return the sort order for migrations which Defaults to {@link VersionSortOrder#LEXICOGRAPHIC} until 3.x.}
 	 */
 	@WithDefault(Defaults.VERSION_SORT_ORDER_VALUE)
 	VersionSortOrder versionSortOrder();

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
@@ -22,6 +22,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 import java.time.Duration;
 import java.util.List;

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
@@ -18,9 +18,10 @@ package ac.simons.neo4j.migrations.quarkus.runtime;
 import ac.simons.neo4j.migrations.core.Defaults;
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
 import ac.simons.neo4j.migrations.core.MigrationsConfig.VersionSortOrder;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 import java.time.Duration;
 import java.util.List;
@@ -32,60 +33,56 @@ import java.util.Optional;
  * @author Michael J. Simons
  * @since 1.2.2
  */
-@ConfigRoot(prefix = "org.neo4j", name = "migrations", phase = ConfigPhase.RUN_TIME)
-public class MigrationsProperties {
+@ConfigMapping(prefix = "org.neo4j.migrations")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface MigrationsProperties {
 
 	/**
 	 * An optional list of external locations that don't become part of the image. Those locations can be changed during
 	 * runtime in contrast to {@link MigrationsBuildTimeProperties#locationsToScan} but can only be used for locations
 	 * inside the filesystem.
 	 */
-	@ConfigItem
-	public Optional<List<String>> externalLocations;
+	Optional<List<String>> externalLocations();
 
 	/**
 	 * Set to {@literal false} to disable migrations at start. An instance of {@link ac.simons.neo4j.migrations.core.Migrations} will
 	 * still be provided to interested parties.
 	 */
-	@ConfigItem(defaultValue = "true")
-	public boolean enabled;
+	@WithDefault("true")
+	boolean enabled();
 
 	/**
 	 * The transaction mode in use (Defaults to "per migration", meaning one script is run in one transaction).
 	 */
-	@ConfigItem(defaultValue = Defaults.TRANSACTION_MODE_VALUE)
-	public MigrationsConfig.TransactionMode transactionMode;
+	@WithDefault(Defaults.TRANSACTION_MODE_VALUE)
+	MigrationsConfig.TransactionMode transactionMode();
 
 	/**
 	 * The database that should be migrated (Neo4j EE 4.0+ only). Leave empty for using the default database.
 	 */
-	@ConfigItem
-	public Optional<String> database;
+	Optional<String> database();
 
 	/**
 	 * The database that should be used for storing informations about migrations (Neo4j EE 4.0+ only). Leave empty for using the default database.
 	 */
-	@ConfigItem
-	public Optional<String> schemaDatabase;
+	Optional<String> schemaDatabase();
 
 	/**
 	 * An alternative user to impersonate during migration. Might have higher privileges than the user connected, which
 	 * will be dropped again after migration. Requires Neo4j EE 4.4+. Leave empty for using the connected user.
 	 */
-	@ConfigItem
-	public Optional<String> impersonatedUser;
+	Optional<String> impersonatedUser();
 
 	/**
 	 * Username recorded as property {@literal by} on the MIGRATED_TO relationship.
 	 */
-	@ConfigItem
-	public Optional<String> installedBy;
+	Optional<String> installedBy();
 
 	/**
 	 * Validating helps you verify that the migrations applied to the database match the ones available locally and is on by default.
 	 */
-	@ConfigItem(defaultValue = Defaults.VALIDATE_ON_MIGRATE_VALUE)
-	public boolean validateOnMigrate;
+	@WithDefault(Defaults.VALIDATE_ON_MIGRATE_VALUE)
+	boolean validateOnMigrate();
 
 	/**
 	 * If you're programming on Windows and working with people who are not (or vice-versa), you'll probably run into
@@ -96,18 +93,17 @@ public class MigrationsProperties {
 	 * Neo4j migrations can handle this by auto-converting CRLF line endings into LF before computing checksums of a
 	 * Cypher-based migration or applying it.
 	 */
-	@ConfigItem(defaultValue = Defaults.AUTOCRLF_VALUE)
-	public boolean autocrlf;
+	@WithDefault(Defaults.AUTOCRLF_VALUE)
+	boolean autocrlf();
 
 	/**
 	 * A configurable delay that will be applied in between applying two migrations.
 	 */
-	@ConfigItem
-	public Optional<Duration> delayBetweenMigrations;
+	Optional<Duration> delayBetweenMigrations();
 
 	/**
 	 * The sort order for migrations. Defaults to {@link VersionSortOrder#LEXICOGRAPHIC} until 3.x.
 	 */
-	@ConfigItem(defaultValue = Defaults.VERSION_SORT_ORDER_VALUE)
-	public VersionSortOrder versionSortOrder;
+	@WithDefault(Defaults.VERSION_SORT_ORDER_VALUE)
+	VersionSortOrder versionSortOrder();
 }

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorder.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorder.java
@@ -56,27 +56,27 @@ public class MigrationsRecorder {
 	) {
 
 		var allLocationsToScan = new ArrayList<String>(
-			buildTimeProperties.locationsToScan.size() + runtimeProperties.externalLocations.map(
+			buildTimeProperties.locationsToScan().size() + runtimeProperties.externalLocations().map(
 				List::size).orElse(0));
-		allLocationsToScan.addAll(buildTimeProperties.locationsToScan);
-		runtimeProperties.externalLocations.ifPresent(locations -> locations.stream()
+		allLocationsToScan.addAll(buildTimeProperties.locationsToScan());
+		runtimeProperties.externalLocations().ifPresent(locations -> locations.stream()
 			.filter(l -> Location.of(l).getType() == Location.LocationType.FILESYSTEM)
 			.forEach(allLocationsToScan::add));
 
 		var config = MigrationsConfig.builder()
 			.withLocationsToScan(allLocationsToScan.toArray(new String[0]))
-			.withPackagesToScan(buildTimeProperties.packagesToScan.map(v -> v.toArray(String[]::new)).orElse(null))
-			.withTransactionMode(runtimeProperties.transactionMode)
-			.withDatabase(runtimeProperties.database.orElse(null))
-			.withSchemaDatabase(runtimeProperties.schemaDatabase.orElse(null))
-			.withImpersonatedUser(runtimeProperties.impersonatedUser.orElse(null))
-			.withInstalledBy(runtimeProperties.installedBy.orElse(null))
-			.withValidateOnMigrate(runtimeProperties.validateOnMigrate)
-			.withAutocrlf(runtimeProperties.autocrlf)
+			.withPackagesToScan(buildTimeProperties.packagesToScan().map(v -> v.toArray(String[]::new)).orElse(null))
+			.withTransactionMode(runtimeProperties.transactionMode())
+			.withDatabase(runtimeProperties.database().orElse(null))
+			.withSchemaDatabase(runtimeProperties.schemaDatabase().orElse(null))
+			.withImpersonatedUser(runtimeProperties.impersonatedUser().orElse(null))
+			.withInstalledBy(runtimeProperties.installedBy().orElse(null))
+			.withValidateOnMigrate(runtimeProperties.validateOnMigrate())
+			.withAutocrlf(runtimeProperties.autocrlf())
 			.withMigrationClassesDiscoverer(discoverer)
 			.withResourceScanner(resourceScanner)
-			.withDelayBetweenMigrations(runtimeProperties.delayBetweenMigrations.orElse(null))
-			.withVersionSortOrder(runtimeProperties.versionSortOrder)
+			.withDelayBetweenMigrations(runtimeProperties.delayBetweenMigrations().orElse(null))
+			.withVersionSortOrder(runtimeProperties.versionSortOrder())
 			.build();
 
 		return new RuntimeValue<>(config);
@@ -89,7 +89,7 @@ public class MigrationsRecorder {
 	 * @return A runtime value containing the enabled-flag
 	 */
 	public RuntimeValue<Boolean> isEnabled(MigrationsProperties runtimeProperties) {
-		return new RuntimeValue<>(runtimeProperties.enabled);
+		return new RuntimeValue<>(runtimeProperties.enabled());
 	}
 
 	/**

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,1 +1,1 @@
-ac.simons.neo4j.migrations.quarkus.runtime.CustomConfigBuilder
+ac.simons.neo4j.migrations.quarkus.runtime.MigrationsConfigCustomizer

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+ac.simons.neo4j.migrations.quarkus.runtime.CustomConfigBuilder

--- a/neo4j-migrations-quarkus-parent/runtime/src/test/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorderTest.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/test/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorderTest.java
@@ -16,6 +16,8 @@
 package ac.simons.neo4j.migrations.quarkus.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ac.simons.neo4j.migrations.core.MigrationsConfig;
 
@@ -33,24 +35,24 @@ class MigrationsRecorderTest {
 	@Test
 	void migrationConfigShouldWork() {
 
-		var properties = new MigrationsProperties();
-		properties.autocrlf = true;
-		properties.database = Optional.of("db");
-		properties.installedBy = Optional.of("ich");
-		properties.impersonatedUser = Optional.of("hg");
-		properties.schemaDatabase = Optional.of("db2");
-		properties.transactionMode = MigrationsConfig.TransactionMode.PER_STATEMENT;
-		properties.validateOnMigrate = false;
-		properties.externalLocations = Optional.of(List.of("file:///bazbar", "dropped"));
-		properties.delayBetweenMigrations = Optional.empty();
+		var properties = mock(MigrationsProperties.class);
+		when(properties.autocrlf()).thenReturn(true);
+		when(properties.database()).thenReturn(Optional.of("db"));
+		when(properties.installedBy()).thenReturn(Optional.of("ich"));
+		when(properties.impersonatedUser()).thenReturn(Optional.of("hg"));
+		when(properties.schemaDatabase()).thenReturn(Optional.of("db2"));
+		when(properties.transactionMode()).thenReturn(MigrationsConfig.TransactionMode.PER_STATEMENT);
+		when(properties.validateOnMigrate()).thenReturn(false);
+		when(properties.externalLocations()).thenReturn(Optional.of(List.of("file:///bazbar", "dropped")));
+		when(properties.delayBetweenMigrations()).thenReturn(Optional.empty());
 
-		var buildTimeProperties = new MigrationsBuildTimeProperties();
-		buildTimeProperties.packagesToScan = Optional.of(List.of("foo"));
-		buildTimeProperties.locationsToScan = List.of("bar");
+		var buildTimeProperties = mock(MigrationsBuildTimeProperties.class);
+		when(buildTimeProperties.packagesToScan()).thenReturn(Optional.of(List.of("foo")));
+		when(buildTimeProperties.locationsToScan()).thenReturn(List.of("bar"));
 
 		var config = new MigrationsRecorder().recordConfig(buildTimeProperties, properties, null, null).getValue();
 
-		assertThat(config.getPackagesToScan()).containsExactlyElementsOf(buildTimeProperties.packagesToScan.get());
+		assertThat(config.getPackagesToScan()).containsExactlyElementsOf(buildTimeProperties.packagesToScan().orElse(List.of()));
 		assertThat(config.isAutocrlf()).isTrue();
 		assertThat(config.getOptionalDatabase()).hasValue("db");
 		assertThat(config.getOptionalInstalledBy()).hasValue("ich");
@@ -68,19 +70,19 @@ class MigrationsRecorderTest {
 	@Test
 	void delayShallBeConfigurable() {
 
-		var properties = new MigrationsProperties();
-		properties.autocrlf = true;
-		properties.database = Optional.empty();
-		properties.installedBy = Optional.empty();
-		properties.impersonatedUser = Optional.empty();
-		properties.schemaDatabase = Optional.empty();
-		properties.transactionMode = MigrationsConfig.TransactionMode.PER_STATEMENT;
-		properties.externalLocations = Optional.empty();
-		properties.delayBetweenMigrations = Optional.of(Duration.ofSeconds(1));
+		var properties = mock(MigrationsProperties.class);
+		when(properties.autocrlf()).thenReturn(true);
+		when(properties.database()).thenReturn(Optional.empty());
+		when(properties.installedBy()).thenReturn(Optional.empty());
+		when(properties.impersonatedUser()).thenReturn(Optional.empty());
+		when(properties.schemaDatabase()).thenReturn(Optional.empty());
+		when(properties.transactionMode()).thenReturn(MigrationsConfig.TransactionMode.PER_STATEMENT);
+		when(properties.externalLocations()).thenReturn(Optional.empty());
+		when(properties.delayBetweenMigrations()).thenReturn(Optional.of(Duration.ofSeconds(1)));
 
-		var buildTimeProperties = new MigrationsBuildTimeProperties();
-		buildTimeProperties.packagesToScan = Optional.empty();
-		buildTimeProperties.locationsToScan = List.of("bar");
+		var buildTimeProperties = mock(MigrationsBuildTimeProperties.class);
+		when(buildTimeProperties.packagesToScan()).thenReturn(Optional.empty());
+		when(buildTimeProperties.locationsToScan()).thenReturn(List.of("bar"));
 
 		var config = new MigrationsRecorder().recordConfig(buildTimeProperties, properties, null, null).getValue();
 		assertThat(config.getOptionalDelayBetweenMigrations()).hasValue(Duration.ofSeconds(1));

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
 					<configuration>
-						<forceJavacCompilerUse>true</forceJavacCompilerUse>
+						<forceLegacyJavacApi>true</forceLegacyJavacApi>
 						<showWarnings>true</showWarnings>
 						<compilerArgs>
 							<arg>-Xlint:all,-options,-path,-processing,-classfile</arg>
@@ -428,7 +428,7 @@
 						<execution>
 							<id>default-testCompile</id>
 							<configuration>
-								<forceJavacCompilerUse>true</forceJavacCompilerUse>
+								<forceLegacyJavacApi>true</forceLegacyJavacApi>
 								<showWarnings>true</showWarnings>
 								<compilerArgs>
 									<arg>-Xlint:all,-options,-path,-processing,-classfile,-exports,-missing-explicit-ctor</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 		<project.build.docs.branch>main</project.build.docs.branch>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<quarkus-neo4j.version>4.2.2</quarkus-neo4j.version>
-		<quarkus.version>3.13.2</quarkus.version>
+		<quarkus.version>3.14.0</quarkus.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<!--
 		 I am not in the mood for _yet_ another player in the Neo4j-Java-Driver 5.x, Spring Boot 3, Quarkus Future battle of version fu


### PR DESCRIPTION
Hello @radcortez

I hope you have time to have a look again.
I cannot find for the life of it the different in the 3rd extension now to the 2nd I migrated.

If you run the tests on this branch

```
./mvnw -DskipCoreTests -pl neo4j-migrations-quarkus-parent/runtime -pl neo4j-migrations-quarkus-parent/deployment -pl neo4j-migrations-quarkus-parent/integration-tests -am -Dcheckstyle.skip clean verify
```

like this, `BlahTest` fails with 

```
[ERROR] ac.simons.neo4j.migrations.quarkus.test.BlahTest -- Time elapsed: 2.429 s <<< ERROR!
java.lang.ExceptionInInitializerError
	at io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:534)
	at java.base/java.lang.Class.forName(Class.java:513)
	at io.quarkus.runner.bootstrap.StartupActionImpl.run(StartupActionImpl.java:289)
	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:661)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	Suppressed: java.lang.NoClassDefFoundError: Could not initialize class io.quarkus.runtime.generated.Config
		at java.base/java.lang.Class.forName0(Native Method)
		at java.base/java.lang.Class.forName(Class.java:534)
		at java.base/java.lang.Class.forName(Class.java:513)
		at io.quarkus.runner.bootstrap.StartupActionImpl.run(StartupActionImpl.java:293)
		... 2 more
	Caused by: java.lang.ExceptionInInitializerError: Exception io.smallrye.config.ConfigValidationException: Configuration validation failed:
	SRCFG00050: org.neo4j.migrations.external-locations in PropertiesConfigSource[source=file:/var/folders/_y/ms08hd653_n_qgljb3svns100000gq/T/quarkus-unit-test16212579664370349347/app-root/application.properties]:3 does not map to any root [in thread "main"]
		at io.smallrye.config.SmallRyeConfig.buildMappings(SmallRyeConfig.java:139)
		at io.smallrye.config.SmallRyeConfig.<init>(SmallRyeConfig.java:93)
		at io.smallrye.config.SmallRyeConfigBuilder.build(SmallRyeConfigBuilder.java:736)
		at io.quarkus.runtime.generated.Config.<clinit>(Unknown Source)
		at io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
		at java.base/java.lang.Class.forName0(Native Method)
		at java.base/java.lang.Class.forName(Class.java:534)
		at java.base/java.lang.Class.forName(Class.java:513)
		at io.quarkus.runner.bootstrap.StartupActionImpl.run(StartupActionImpl.java:289)
		... 2 more
Caused by: io.smallrye.config.ConfigValidationException: Configuration validation failed:
	SRCFG00050: org.neo4j.migrations.external-locations in PropertiesConfigSource[source=file:/var/folders/_y/ms08hd653_n_qgljb3svns100000gq/T/quarkus-unit-test16212579664370349347/app-root/application.properties]:3 does not map to any root
	at io.smallrye.config.SmallRyeConfig.buildMappings(SmallRyeConfig.java:139)
	at io.smallrye.config.SmallRyeConfig.<init>(SmallRyeConfig.java:93)
	at io.smallrye.config.SmallRyeConfigBuilder.build(SmallRyeConfigBuilder.java:736)
	at io.quarkus.runtime.generated.Config.<clinit>(Unknown Source)
	... 7 more
```

despite having this one in place

```
public class CustomConfigBuilder implements SmallRyeConfigBuilderCustomizer {
	@Override
	public void configBuilder(final SmallRyeConfigBuilder builder) {
		builder.withMappingIgnore("org.neo4j.migrations.**");
	}
}
```

and this time also with the correct names and getting invoked.

Any ideas? I am down already to debugging the config map (see `F.java`)