### PR TITLE
build: Switch GraalVM `-march` flag from `native` to `compatibility`

### DIFF
--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -299,7 +299,7 @@
 							<buildArgs>
 								<arg>--no-fallback</arg>
 								<arg>-Os</arg>
-								<arg>-march=native</arg>
+								<arg>-march=compatibility</arg>
 								<arg>-H:+UnlockExperimentalVMOptions</arg>
 							</buildArgs>
 						</configuration>


### PR DESCRIPTION
`-march=native` can improve performance but will add a hard requirement for every CPU extension present on your CPU. This can cause issues with older CPUs or CPUs from different vendors (AMD vs Intel).

`-march=compatibility` will ensure the best compatibility with a potential performance penalty. In my experience this is not usually noticable in applications like neo4j-migrations.

If performance is a concern then another option would be to remove the flag and trust the defaults of GraalVM, which according to their docs are: `x86-64-v3 on AMD64 and armv8-a on AArch64`