### PR TITLE
feat: Provide an option to enable Flyway compatible checksums.

### DIFF
--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/MigrationsCli.java
@@ -257,6 +257,13 @@ public final class MigrationsCli implements Runnable {
 	)
 	private String target;
 
+	@Option(
+		names = {"--use-flyway-compatible-checksums"},
+		description = "Use this flag to enable Flyway compatible checksums.",
+		defaultValue = Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS_VALUE
+	)
+	private boolean useFlywayCompatibleChecksums;
+
 	@Spec
 	private CommandSpec commandSpec;
 
@@ -312,6 +319,7 @@ public final class MigrationsCli implements Runnable {
 			.withDelayBetweenMigrations(delayBetweenMigrations)
 			.withVersionSortOrder(versionSortOrder)
 			.withOutOfOrderAllowed(outOfOrder)
+			.withFlywayCompatibleChecksums(useFlywayCompatibleChecksums)
 			.withTarget(target)
 			.build();
 

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/MigrationsCliTest.java
@@ -161,6 +161,26 @@ class MigrationsCliTest {
 		assertThat(cli.getConfig().isOutOfOrder()).isTrue();
 	}
 
+	@Test
+	void useFlywayCompatibleChecksumsShouldBeDisabled() {
+
+		MigrationsCli cli = new MigrationsCli();
+		CommandLine commandLine = new CommandLine(cli);
+		commandLine.parseArgs();
+
+		assertThat(cli.getConfig().isUseFlywayCompatibleChecksums()).isFalse();
+	}
+
+	@Test
+	void useFlywayCompatibleChecksumsShouldBeEnabled() {
+
+		MigrationsCli cli = new MigrationsCli();
+		CommandLine commandLine = new CommandLine(cli);
+		commandLine.parseArgs("--use-flyway-compatible-checksums");
+
+		assertThat(cli.getConfig().isUseFlywayCompatibleChecksums()).isTrue();
+	}
+
 	@Test // GH-1536
 	void targetShouldBeNullByDefault() {
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -193,8 +193,12 @@ final class ChainBuilder {
 					Record row = result.single();
 					List<Relationship> repetitions = row.get("repetitions").asList(Value::asRelationship);
 					row.get("p").asPath().forEach(segment -> {
+						var end = segment.end();
+						if (end.get("flyway_failed").asBoolean(false) || !end.containsKey("version") || end.get("type").asString().equals("DELETE")) {
+							return;
+						}
 						Element chainElement = DefaultMigrationChainElement.appliedElement(segment, repetitions);
-						chain.put(MigrationVersion.withValue(chainElement.getVersion(), segment.end().get("repeatable").asBoolean(false)), chainElement);
+						chain.put(MigrationVersion.withValue(chainElement.getVersion(), end.get("repeatable").asBoolean(false)), chainElement);
 					});
 				}
 				return chain;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResource.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherResource.java
@@ -60,8 +60,9 @@ public sealed interface CypherResource permits DefaultCypherResource {
 	static CypherResource of(ResourceContext context) {
 		var url = context.getUrl();
 		var autocrlf = context.getConfig().isAutocrlf();
+		var useFlywayCompatibleChecksums = context.getConfig().isUseFlywayCompatibleChecksums();
 
-		return new DefaultCypherResource(ResourceContext.generateIdentifierOf(url), autocrlf,
+		return new DefaultCypherResource(ResourceContext.generateIdentifierOf(url), autocrlf, useFlywayCompatibleChecksums,
 			context::openStream);
 	}
 
@@ -73,7 +74,7 @@ public sealed interface CypherResource permits DefaultCypherResource {
 	 * @since 1.8.0
 	 */
 	static WithContent withContent(String content) {
-		return identifier -> new DefaultCypherResource(identifier, Defaults.AUTOCRLF,
+		return identifier -> new DefaultCypherResource(identifier, Defaults.AUTOCRLF, Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS,
 			() -> new ByteArrayInputStream(content.getBytes(Defaults.CYPHER_SCRIPT_ENCODING)));
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Defaults.java
@@ -123,6 +123,19 @@ public final class Defaults {
 	 */
 	public static final String OUT_OF_ORDER_VALUE = "false";
 
+	/**
+	 * Default setting for {@code useFlywayCompatibleChecksums}.
+	 * @since 2.17.0
+	 */
+	public static final boolean USE_FLYWAY_COMPATIBLE_CHECKSUMS = false;
+
+	/**
+	 * Default setting for {@code useFlywayCompatibleChecksums} but as a {@link String string value} to be used in
+	 * configuration that requires defaults given as string.
+	 * @since 2.17.0
+	 */
+	public static final String USE_FLYWAY_COMPATIBLE_CHECKSUMS_VALUE = "false";
+
 	private Defaults() {
 	}
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
@@ -141,6 +141,8 @@ public final class MigrationsConfig {
 
 	private final String target;
 
+	private final boolean useFlywayCompatibleChecksums;
+
 	private MigrationsConfig(Builder builder) {
 
 		this.packagesToScan =
@@ -163,6 +165,7 @@ public final class MigrationsConfig {
 		this.versionSortOrder = builder.versionSortOrder;
 		this.transactionTimeout = builder.transactionTimeout;
 		this.outOfOrder = builder.outOfOrder;
+		this.useFlywayCompatibleChecksums = builder.useFlywayCompatibleChecksums;
 		if (builder.target == null || builder.target.isBlank()) {
 			this.target = null;
 		} else {
@@ -301,6 +304,15 @@ public final class MigrationsConfig {
 	}
 
 	/**
+	 * {@return if Flyway compatible checksums should be used}
+	 *
+	 * @since 2.17.0
+	 */
+	public boolean isUseFlywayCompatibleChecksums() {
+		return useFlywayCompatibleChecksums;
+	}
+
+	/**
 	 * Helper method to pretty print this configuration into a logger (on level {@literal INFO} respectively {@literal WARNING}.
 	 *
 	 * @param logger  the logger to print to
@@ -418,6 +430,8 @@ public final class MigrationsConfig {
 		private boolean outOfOrder = Defaults.OUT_OF_ORDER;
 
 		private String target;
+
+		private boolean useFlywayCompatibleChecksums = Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS;
 
 		private Builder() {
 			// The explicit constructor has been added to avoid warnings when Neo4j-Migrations
@@ -655,6 +669,18 @@ public final class MigrationsConfig {
 		 */
 		public Builder withTarget(String newTarget) {
 			this.target = newTarget;
+			return this;
+		}
+
+		/**
+		 * Enables or disables migrations with checksums in Flyway compatible mode
+		 *
+		 * @param enabled use {@literal true} to enable Flyway compatible checksums
+		 * @return The builder for further customization
+		 * @since 2.17.0
+		 */
+		public Builder withFlywayCompatibleChecksums(boolean enabled) {
+			this.useFlywayCompatibleChecksums = enabled;
 			return this;
 		}
 

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/DefaultCypherResourceTest.java
@@ -151,6 +151,20 @@ class DefaultCypherResourceTest {
 		assertThat(cypherResource.getChecksum()).isEqualTo("1916418554");
 	}
 
+	@ParameterizedTest
+	@CsvSource(
+		textBlock = """
+			true,-626195011
+			false,1491717096
+			"""
+	)
+	void shouldConvertLineEndings(boolean enabled, String expected) {
+		URL resource = TestResources.class.getResource("/my/awesome/migrations/V5000__WithCommentAtEnd.cypher");
+		DefaultCypherResource cypherResource = (DefaultCypherResource) CypherResource.of(ResourceContext.of(resource, MigrationsConfig.builder()
+			.withFlywayCompatibleChecksums(enabled).build()));
+		assertThat(cypherResource.getChecksum()).isEqualTo(expected);
+	}
+
 	@Test
 	void shouldBeAbleToReadFromJar() {
 

--- a/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
+++ b/neo4j-migrations-maven-plugin/src/main/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojo.java
@@ -142,6 +142,13 @@ abstract class AbstractConnectedMojo extends AbstractMojo {
 	private boolean outOfOrder;
 
 	/**
+	 * Whether to use Flyway compatible checksums or not.
+	 * @since 2.17.0
+	 */
+	@Parameter(defaultValue = Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS_VALUE)
+	private boolean useFlywayCompatibleChecksums;
+
+	/**
 	 * Use this option to specify a valid target version up to which migrations
 	 * should be considered. Can also be one of current, latest or next.
 	 *
@@ -185,6 +192,7 @@ abstract class AbstractConnectedMojo extends AbstractMojo {
 			.withImpersonatedUser(impersonatedUser)
 			.withVersionSortOrder(versionSortOrder)
 			.withOutOfOrderAllowed(outOfOrder)
+			.withFlywayCompatibleChecksums(useFlywayCompatibleChecksums)
 			.withTarget(target)
 			.build();
 

--- a/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
+++ b/neo4j-migrations-maven-plugin/src/test/java/ac/simons/neo4j/migrations/maven/AbstractConnectedMojoTest.java
@@ -178,6 +178,32 @@ public class AbstractConnectedMojoTest {
 		assertThat(infoMojo.getConfig().isOutOfOrder()).isTrue();
 	}
 
+	@Test
+	public void useFlywayCompatibleChecksumsShouldBeDisabled() throws Exception {
+
+		File pom = new File("target/test-classes/with-imp-and-schema/");
+		assertThat(pom)
+			.isNotNull()
+			.exists();
+
+		InfoMojo infoMojo = (InfoMojo) rule.lookupConfiguredMojo(pom, "info");
+		assertThat(infoMojo).isNotNull();
+		assertThat(infoMojo.getConfig().isUseFlywayCompatibleChecksums()).isFalse();
+	}
+
+	@Test
+	public void useFlywayCompatibleChecksumsShouldBeEnabled() throws Exception {
+
+		File pom = new File("target/test-classes/out-of-order/");
+		assertThat(pom)
+			.isNotNull()
+			.exists();
+
+		InfoMojo infoMojo = (InfoMojo) rule.lookupConfiguredMojo(pom, "info");
+		assertThat(infoMojo).isNotNull();
+		assertThat(infoMojo.getConfig().isUseFlywayCompatibleChecksums()).isTrue();
+	}
+
 	@Test // GH-1536
 	public void targetShouldBeNullByDefault() throws Exception {
 

--- a/neo4j-migrations-maven-plugin/src/test/resources/out-of-order/pom.xml
+++ b/neo4j-migrations-maven-plugin/src/test/resources/out-of-order/pom.xml
@@ -36,6 +36,7 @@
 					<password>secret</password>
 					<locationsToScan>classpath:/wontwork</locationsToScan>
 					<outOfOrder>true</outOfOrder>
+					<useFlywayCompatibleChecksums>true</useFlywayCompatibleChecksums>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsProperties.java
@@ -134,6 +134,15 @@ public interface MigrationsProperties {
 	boolean outOfOrder();
 
 	/**
+	 * When this flag is set to {@literal true}, checksums will be computed with the same algorithm Flyway uses.
+	 *
+	 * @return whether to use Flyway compatible checksums or not
+	 * @since 2.17.0
+	 */
+	@WithDefault(Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS_VALUE)
+	boolean useFlywayCompatibleChecksums();
+
+	/**
 	 * Configures the target version up to which migrations should be considered. This must be a valid migration version,
 	 * or one of the special values {@code current}, {@code latest} or {@code next}.
 	 *

--- a/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorder.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/main/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorder.java
@@ -79,6 +79,7 @@ public class MigrationsRecorder {
 			.withDelayBetweenMigrations(runtimeProperties.delayBetweenMigrations().orElse(null))
 			.withVersionSortOrder(runtimeProperties.versionSortOrder())
 			.withOutOfOrderAllowed(runtimeProperties.outOfOrder())
+			.withFlywayCompatibleChecksums(runtimeProperties.useFlywayCompatibleChecksums())
 			.withTarget(runtimeProperties.target().orElse(null))
 			.build();
 

--- a/neo4j-migrations-quarkus-parent/runtime/src/test/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorderTest.java
+++ b/neo4j-migrations-quarkus-parent/runtime/src/test/java/ac/simons/neo4j/migrations/quarkus/runtime/MigrationsRecorderTest.java
@@ -115,6 +115,33 @@ class MigrationsRecorderTest {
 		assertThat(config.isOutOfOrder()).isTrue();
 	}
 
+	@Test
+	void useFlywayCompatibleChecksumsShouldBeDisabled() {
+
+		var properties = mock(MigrationsProperties.class);
+
+		var buildTimeProperties = mock(MigrationsBuildTimeProperties.class);
+		when(buildTimeProperties.packagesToScan()).thenReturn(Optional.empty());
+		when(buildTimeProperties.locationsToScan()).thenReturn(List.of("bar"));
+
+		var config = new MigrationsRecorder().recordConfig(buildTimeProperties, properties, null, null).getValue();
+		assertThat(config.isUseFlywayCompatibleChecksums()).isFalse();
+	}
+
+	@Test
+	void useFlywayCompatibleChecksumsShouldBeEnabled() {
+
+		var properties = mock(MigrationsProperties.class);
+		when(properties.useFlywayCompatibleChecksums()).thenReturn(true);
+
+		var buildTimeProperties = mock(MigrationsBuildTimeProperties.class);
+		when(buildTimeProperties.packagesToScan()).thenReturn(Optional.empty());
+		when(buildTimeProperties.locationsToScan()).thenReturn(List.of("bar"));
+
+		var config = new MigrationsRecorder().recordConfig(buildTimeProperties, properties, null, null).getValue();
+		assertThat(config.isUseFlywayCompatibleChecksums()).isTrue();
+	}
+
 	@Test // GH-1536
 	void targetShouldBeNullByDefault() {
 

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfiguration.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfiguration.java
@@ -82,6 +82,7 @@ public class MigrationsAutoConfiguration {
 			.withVersionSortOrder(migrationsProperties.getVersionSortOrder())
 			.withMigrationClassesDiscoverer(applicationContextAwareDiscoverer.getIfAvailable())
 			.withOutOfOrderAllowed(migrationsProperties.isOutOfOrder())
+			.withFlywayCompatibleChecksums(migrationsProperties.isUseFlywayCompatibleChecksums())
 			.withTarget(migrationsProperties.getTarget());
 		configBuilderCustomizers.orderedStream().forEach(customizer -> customizer.customize(builder));
 		return builder.build();

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsProperties.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/main/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsProperties.java
@@ -134,6 +134,13 @@ public class MigrationsProperties {
 	private boolean outOfOrder = Defaults.OUT_OF_ORDER;
 
 	/**
+	 * When this flag is set to {@literal true}, checksums will be computed with the same algorithm Flyway uses.
+	 *
+	 * @since 2.17.0
+	 */
+	private boolean useFlywayCompatibleChecksums = Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS;
+
+	/**
 	 * Configures the target version up to which migrations should be considered. This must be a valid migration version,
 	 * or one of the special values {@code current}, {@code latest} or {@code next}.
 	 *
@@ -356,6 +363,23 @@ public class MigrationsProperties {
 	 */
 	public boolean isOutOfOrder() {
 		return outOfOrder;
+	}
+
+	/**
+	 * {@return whether to use Flyway compatible checksums or not}
+	 * @since 2.17.0
+	 */
+	public boolean isUseFlywayCompatibleChecksums() {
+		return useFlywayCompatibleChecksums;
+	}
+
+	/**
+	 * Configures whether Flyway compatible checksums should be used or not
+	 * @param useFlywayCompatibleChecksums the new value for the corresponding flag
+	 * @since 2.17.0
+	 */
+	public void setUseFlywayCompatibleChecksums(boolean useFlywayCompatibleChecksums) {
+		this.useFlywayCompatibleChecksums = useFlywayCompatibleChecksums;
 	}
 
 	/**

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationTest.java
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/src/test/java/ac/simons/neo4j/migrations/springframework/boot/autoconfigure/MigrationsAutoConfigurationTest.java
@@ -380,6 +380,27 @@ class MigrationsAutoConfigurationTest {
 			assertThat(config.isOutOfOrder()).isTrue();
 		}
 
+		@Test
+		void useFlywayCompatibleChecksumsShouldBeDisabled() {
+
+			MigrationsProperties properties = new MigrationsProperties();
+			properties.setPackagesToScan(new String[] { "na" });
+
+			MigrationsConfig config = new MigrationsAutoConfiguration().neo4jMigrationsConfig(resourceLoader, properties, noCustomizer(), noSpringDiscoverer());
+			assertThat(config.isUseFlywayCompatibleChecksums()).isFalse();
+		}
+
+		@Test
+		void useFlywayCompatibleChecksumsShouldBeEnabled() {
+
+			MigrationsProperties properties = new MigrationsProperties();
+			properties.setPackagesToScan(new String[] { "na" });
+			properties.setUseFlywayCompatibleChecksums(true);
+
+			MigrationsConfig config = new MigrationsAutoConfiguration().neo4jMigrationsConfig(resourceLoader, properties, noCustomizer(), noSpringDiscoverer());
+			assertThat(config.isUseFlywayCompatibleChecksums()).isTrue();
+		}
+
 		@Test // GH-1536
 		void targetShouldBeNullByDefault() {
 


### PR DESCRIPTION
Also, prepare for some additional metadata in the graph and skip non-supported entries.
