### PR TITLE
refactor: Restrict the output of `dbms.components()` to `'Neo4j Kernel'`.

### DIFF
--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationContext.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationContext.java
@@ -195,12 +195,13 @@ final class DefaultMigrationContext implements MigrationContext {
 		TransactionCallback<ExtendedResultSummary> extendedResultSummaryTransactionWork;
 		if (hasDbmsProcedures()) {
 			extendedResultSummaryTransactionWork = tx -> {
-				Result result = tx.run(""
-					+ "CALL dbms.procedures() YIELD name "
-					+ "WHERE name = 'dbms.showCurrentUser' "
-					+ "WITH count(*) > 0 AS showCurrentUserExists "
-					+ "CALL dbms.components() YIELD versions, edition "
-					+ "RETURN showCurrentUserExists, 'Neo4j/' + versions[0] AS version, edition"
+				Result result = tx.run("""
+					CALL dbms.procedures() YIELD name
+					WHERE name = 'dbms.showCurrentUser'
+					WITH count(*) > 0 AS showCurrentUserExists
+					CALL dbms.components() YIELD name, versions, edition
+					WHERE name = 'Neo4j Kernel'
+					RETURN showCurrentUserExists, 'Neo4j/' + versions[0] AS version, edition"""
 				);
 				Record singleResultRecord = result.single();
 				boolean showCurrentUserExists = singleResultRecord.get("showCurrentUserExists").asBoolean();
@@ -212,9 +213,10 @@ final class DefaultMigrationContext implements MigrationContext {
 		} else {
 			extendedResultSummaryTransactionWork = tx -> {
 				boolean showCurrentUserExists = tx.run("SHOW PROCEDURES YIELD name WHERE name = 'dbms.showCurrentUser' RETURN count(*)").single().get(0).asInt() == 1;
-				Result result = tx.run(""
-					+ "CALL dbms.components() YIELD versions, edition "
-					+ "RETURN 'Neo4j/' + versions[0] AS version, edition"
+				Result result = tx.run("""
+					CALL dbms.components() YIELD name, versions, edition
+					WHERE name = 'Neo4j Kernel'
+					RETURN 'Neo4j/' + versions[0] AS version, edition"""
 				);
 				Record singleResultRecord = result.single();
 				String version = singleResultRecord.get("version").asString();

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultRefactoringContext.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultRefactoringContext.java
@@ -83,7 +83,7 @@ final class DefaultRefactoringContext implements RefactoringContext {
 				availableVersion = this.version;
 				if (availableVersion == null) {
 					String value = sessionSupplier.get()
-						.executeRead(tx -> tx.run(new Query("CALL dbms.components() YIELD versions RETURN versions[0] AS version")).single())
+						.executeRead(tx -> tx.run(new Query("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions[0] AS version")).single())
 						.get("version").asString();
 					this.version = Neo4jVersion.of(value);
 					availableVersion = this.version;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
@@ -158,7 +158,7 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
 	List<CatalogItem<?>> findBTreeBasedItems(QueryRunner queryRunner) {
 
-		var versions = queryRunner.run(new Query("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN version")).single().get("versions").asList(Value::asString);
+		var versions = queryRunner.run(new Query("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions")).single().get("versions").asList(Value::asString);
 		if (versions.stream().anyMatch(v -> v.startsWith("5."))) {
 			return List.of();
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
@@ -158,7 +158,7 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
 	List<CatalogItem<?>> findBTreeBasedItems(QueryRunner queryRunner) {
 
-		var versions = queryRunner.run(new Query("CALL dbms.components() YIELD versions")).single().get("versions").asList(Value::asString);
+		var versions = queryRunner.run(new Query("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN version")).single().get("versions").asList(Value::asString);
 		if (versions.stream().anyMatch(v -> v.startsWith("5."))) {
 			return List.of();
 		}


### PR DESCRIPTION
Signed-off-by: Michael Simons <michael@simons.ac>
