### PR TITLE
feat: Enhance the Neo4j-Migrations core module so that it uses and exposes JSpecify annotations.

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,14 @@
 -XX:+IgnoreUnrecognizedVMOptions
 -Dguice_custom_class_loading=CHILD
 --enable-native-access=ALL-UNNAMED
+
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -54,6 +54,10 @@ Please add yourself as an `@author` to the `.java` files you added or that modif
 
 WARNING: As of writing a loose list of how things needs to be run, not exhaustive.
 
+=== JSpecify and `NULL` checking
+
+The Maven build runs by default with Error Prone and NullAway enabled. IntelliJ and other IDEs might have problems with that. To help them, you can disable the `nullAway` profile in their corresponding Maven settings.
+
 === Producing native binaries
 
 NOTE: Native binaries for Windows, Unix and macOS are supplied since 0.3.1 at https://github.com/michael-simons/neo4j-migrations/releases[the releases page].

--- a/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-catalog</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor-api</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor</artifactId>

--- a/extensions/neo4j-migrations-formats-adoc/pom.xml
+++ b/extensions/neo4j-migrations-formats-adoc/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-csv/pom.xml
+++ b/extensions/neo4j-migrations-formats-csv/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-markdown/pom.xml
+++ b/extensions/neo4j-migrations-formats-markdown/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/neo4j-migrations-bom/pom.xml
+++ b/neo4j-migrations-bom/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-bom</artifactId>

--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cli</artifactId>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations</artifactId>
@@ -34,10 +34,15 @@
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>io.github.classgraph</groupId>
 			<artifactId>classgraph</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j</groupId>

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractRepairmentResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/AbstractRepairmentResult.java
@@ -17,6 +17,8 @@ package ac.simons.neo4j.migrations.core;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Contains shared state for repair results (deleting migrations is considered a repairing
  * attempt as well).
@@ -27,7 +29,7 @@ import java.util.Optional;
 abstract sealed class AbstractRepairmentResult implements DatabaseOperationResult
 		permits DeleteResult, RepairmentResult {
 
-	private final String affectedDatabase;
+	@Nullable private final String affectedDatabase;
 
 	private final long nodesDeleted;
 
@@ -39,8 +41,8 @@ abstract sealed class AbstractRepairmentResult implements DatabaseOperationResul
 
 	private final long propertiesSet;
 
-	AbstractRepairmentResult(String affectedDatabase, long nodesDeleted, long nodesCreated, long relationshipsDeleted,
-			long relationshipsCreated, long propertiesSet) {
+	AbstractRepairmentResult(@Nullable String affectedDatabase, long nodesDeleted, long nodesCreated,
+			long relationshipsDeleted, long relationshipsCreated, long propertiesSet) {
 		this.affectedDatabase = affectedDatabase;
 		this.nodesDeleted = nodesDeleted;
 		this.nodesCreated = nodesCreated;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedMigration.java
@@ -67,6 +67,7 @@ import ac.simons.neo4j.migrations.core.internal.ThrowingErrorHandler;
 import ac.simons.neo4j.migrations.core.internal.XMLSchemaConstants;
 import ac.simons.neo4j.migrations.core.refactorings.Counters;
 import ac.simons.neo4j.migrations.core.refactorings.Refactoring;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.QueryRunner;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.Neo4jException;
@@ -627,9 +628,11 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 	interface VersionSpecificOperation extends Operation {
 
 		/**
-		 * {@return the version at which this operation has been defined}
+		 * Returns the version at which this operation has been defined or {@literal null}
+		 * when backed by a local item.
+		 * @return an optional migration version
 		 */
-		MigrationVersion definedAt();
+		@Nullable MigrationVersion definedAt();
 
 	}
 
@@ -764,11 +767,11 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 
 	private static class DefaultOperationBuilder<T extends Operation> implements OperationBuilder<T>, VerifyBuilder {
 
-		private final Operator operator;
+		@Nullable private final Operator operator;
 
-		private Name reference;
+		@Nullable private Name reference;
 
-		private CatalogItem<?> item;
+		@Nullable private CatalogItem<?> item;
 
 		private boolean idempotent;
 
@@ -778,7 +781,7 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 
 		private boolean includingOptions = false;
 
-		DefaultOperationBuilder(final Operator operator) {
+		DefaultOperationBuilder(@Nullable final Operator operator) {
 			this.operator = operator;
 		}
 
@@ -866,16 +869,16 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 	private abstract static class AbstractItemBasedOperation
 			implements VersionSpecificOperation, ItemSpecificOperation {
 
-		protected final MigrationVersion definedAt;
+		@Nullable protected final MigrationVersion definedAt;
 
-		protected final Name reference;
+		@Nullable protected final Name reference;
 
-		protected final CatalogItem<?> localItem;
+		@Nullable protected final CatalogItem<?> localItem;
 
 		protected final boolean idempotent;
 
-		AbstractItemBasedOperation(MigrationVersion definedAt, Name reference, CatalogItem<?> localItem,
-				boolean idempotent) {
+		AbstractItemBasedOperation(@Nullable MigrationVersion definedAt, @Nullable Name reference,
+				@Nullable CatalogItem<?> localItem, boolean idempotent) {
 
 			if (definedAt == null && localItem == null) {
 				throw new IllegalArgumentException("Without a version, a concrete, local item is required.");
@@ -890,11 +893,12 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 			this.idempotent = idempotent;
 		}
 
-		@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want
-											// here
+		// Generic items, this is exactly what we want here
+		// DataFlow / NullAway: When we end up orElseThrow,
+		// preconditions have been asserted via constructor
+		@SuppressWarnings({ "squid:S1452", "NullAway", "DataFlowIssue" })
 		CatalogItem<?> getRequiredItem(VersionedCatalog catalog) {
 
-			// I want Java9+ and better optionals, so that I can or them
 			if (this.localItem != null) {
 				return this.localItem;
 			}
@@ -906,7 +910,7 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 		}
 
 		@Override
-		public MigrationVersion definedAt() {
+		@Nullable public MigrationVersion definedAt() {
 			return this.definedAt;
 		}
 
@@ -927,7 +931,8 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 	 */
 	static final class DefaultCreateOperation extends AbstractItemBasedOperation implements CreateOperation {
 
-		DefaultCreateOperation(MigrationVersion definedAt, Name reference, CatalogItem<?> item, boolean idempotent) {
+		DefaultCreateOperation(@Nullable MigrationVersion definedAt, @Nullable Name reference,
+				@Nullable CatalogItem<?> item, boolean idempotent) {
 			super(definedAt, reference, item, idempotent);
 		}
 
@@ -986,7 +991,8 @@ final class CatalogBasedMigration implements MigrationWithPreconditions {
 	 */
 	static final class DefaultDropOperation extends AbstractItemBasedOperation implements DropOperation {
 
-		DefaultDropOperation(MigrationVersion definedAt, Name reference, CatalogItem<?> item, boolean idempotent) {
+		DefaultDropOperation(@Nullable MigrationVersion definedAt, @Nullable Name reference,
+				@Nullable CatalogItem<?> item, boolean idempotent) {
 			super(definedAt, reference, item, idempotent);
 		}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedRefactorings.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CatalogBasedRefactorings.java
@@ -37,6 +37,7 @@ import ac.simons.neo4j.migrations.core.refactorings.MigrateBTreeIndexes;
 import ac.simons.neo4j.migrations.core.refactorings.Normalize;
 import ac.simons.neo4j.migrations.core.refactorings.Refactoring;
 import ac.simons.neo4j.migrations.core.refactorings.Rename;
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -92,7 +93,7 @@ final class CatalogBasedRefactorings {
 				() -> createException(node, type, "The addSurrogateKey refactoring requires several parameters"));
 
 		Optional<String> optionalCustomQuery = findParameter(node, PARAMETER_NAME_CUSTOM_QUERY, parameterList);
-		AtomicReference<AddSurrogateKey> refactoring = new AtomicReference<>();
+		AtomicReference<@Nullable AddSurrogateKey> refactoring = new AtomicReference<>();
 		if ("nodes".equals(op)) {
 			findParameterValues(parameterList, "labels").filter(Predicate.not(List::isEmpty))
 				.ifPresentOrElse(labels -> refactoring.set(AddSurrogateKey.toNodes(labels.get(0),
@@ -120,24 +121,28 @@ final class CatalogBasedRefactorings {
 			throw createException(node, type, String.format("`%s` is not a valid rename operation", op));
 		}
 
-		refactoring.updateAndGet(
-				r -> findParameter(node, PARAMETER_NAME_PROPERTY, parameterList).map(p -> r.withProperty(p.trim()))
-					.orElse(r));
-		refactoring.updateAndGet(
-				r -> findParameter(node, "generatorFunction", parameterList).map(p -> r.withGeneratorFunction(p.trim()))
-					.orElse(r));
+		refactoring.updateAndGet(r -> (r != null)
+				? findParameter(node, PARAMETER_NAME_PROPERTY, parameterList).map(p -> r.withProperty(p.trim()))
+					.orElse(r)
+				: null);
+		refactoring.updateAndGet(r -> (r != null)
+				? findParameter(node, "generatorFunction", parameterList).map(p -> r.withGeneratorFunction(p.trim()))
+					.orElse(r)
+				: null);
 
-		return customize(refactoring.get(), node, type, parameterList);
+		return customize(Objects.requireNonNull(refactoring.get(), "Could not determine refactoring"), node, type,
+				parameterList);
 	}
 
+	@SuppressWarnings("squid:S3776")
 	private static ListToVector listToVector(Node node, String type) {
-		String op = type.split("\\.")[1];
+		String op = type.split("\\.", -1)[1];
 
 		NodeList parameterList = findParameterList(node)
 			.orElseThrow(() -> createException(node, type, "The listToVector refactoring requires several parameters"));
 
 		Optional<String> optionalCustomQuery = findParameter(node, PARAMETER_NAME_CUSTOM_QUERY, parameterList);
-		AtomicReference<ListToVector> refactoring = new AtomicReference<>();
+		AtomicReference<@Nullable ListToVector> refactoring = new AtomicReference<>();
 		if ("nodes".equals(op)) {
 			findParameterValues(parameterList, "labels").filter(Predicate.not(List::isEmpty))
 				.ifPresentOrElse(labels -> refactoring
@@ -166,14 +171,16 @@ final class CatalogBasedRefactorings {
 			throw createException(node, type, String.format("`%s` is not a valid listToVector operation", op));
 		}
 
-		refactoring.updateAndGet(
-				r -> findParameter(node, PARAMETER_NAME_PROPERTY, parameterList).map(p -> r.withProperty(p.trim()))
-					.orElse(r));
+		refactoring.updateAndGet(r -> (r != null)
+				? findParameter(node, PARAMETER_NAME_PROPERTY, parameterList).map(p -> r.withProperty(p.trim()))
+					.orElse(r)
+				: null);
 		refactoring.updateAndGet(r -> findParameter(node, "elementType", parameterList)
-			.map(p -> r.withElementType(ListToVector.ElementType.valueOf(p.trim().toUpperCase(Locale.ROOT))))
+			.map(p -> (r != null)
+					? r.withElementType(ListToVector.ElementType.valueOf(p.trim().toUpperCase(Locale.ROOT))) : null)
 			.orElse(r));
 
-		return customize(refactoring.get(), node, type, parameterList);
+		return customize(Objects.requireNonNull(refactoring.get()), node, type, parameterList);
 	}
 
 	private static Refactoring createMigrateBtreeIndexes(Node node, boolean drop) {
@@ -288,7 +295,7 @@ final class CatalogBasedRefactorings {
 	}
 
 	private static Refactoring createRename(Node node, String type) {
-		String op = type.split("\\.")[1];
+		String op = type.split("\\.", -1)[1];
 
 		NodeList parameterList = findParameterList(node).orElseThrow(
 				() -> createException(node, type, "The rename refactoring requires `from` and `to` parameters"));
@@ -318,14 +325,13 @@ final class CatalogBasedRefactorings {
 		return customize(rename, node, type, parameterList);
 	}
 
-	private static IllegalArgumentException createException(Node node, String type, String optionalMessage) {
+	private static IllegalArgumentException createException(Node node, String type, @Nullable String optionalMessage) {
 		return createException(node, type, optionalMessage, null);
 	}
 
-	private static IllegalArgumentException createException(Node node, String type, String optionalMessage,
-			Exception cause) {
-		String typeAsAttribute = (type == null || type.trim().isEmpty()) ? ""
-				: String.format(" type=\"%s\"", type.trim());
+	private static IllegalArgumentException createException(Node node, String type, @Nullable String optionalMessage,
+			@Nullable Exception cause) {
+		String typeAsAttribute = type.trim().isEmpty() ? "" : String.format(" type=\"%s\"", type.trim());
 		String suffix = (optionalMessage != null) ? (": " + optionalMessage) : "";
 		return new IllegalArgumentException(String.format("Cannot parse <%s%s /> into a supported refactoring%s",
 				node.getNodeName(), typeAsAttribute, suffix), cause);
@@ -361,7 +367,8 @@ final class CatalogBasedRefactorings {
 		return Optional.empty();
 	}
 
-	private static Optional<String> findParameter(Node refactoring, String name, NodeList optionalParameters) {
+	private static Optional<String> findParameter(Node refactoring, String name,
+			@Nullable NodeList optionalParameters) {
 
 		return Optional.ofNullable(optionalParameters)
 			.or(() -> findParameterList(refactoring))

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -58,11 +58,12 @@ final class ChainBuilder {
 			return true;
 		}
 
-		if (!(newMigration instanceof MigrationWithPreconditions) || !expectedChecksum.isPresent()) {
+		if (!(newMigration instanceof MigrationWithPreconditions migrationWithPreconditions)
+				|| expectedChecksum.isEmpty()) {
 			return false;
 		}
 
-		return ((MigrationWithPreconditions) newMigration).getAlternativeChecksums().contains(expectedChecksum.get());
+		return migrationWithPreconditions.getAlternativeChecksums().contains(expectedChecksum.get());
 	}
 
 	/**
@@ -97,8 +98,8 @@ final class ChainBuilder {
 		return new DefaultMigrationChain(context.getConnectionDetails(), elements);
 	}
 
-	@SuppressWarnings("squid:S3776") // Yep, this is a complex validation, but it still
-										// fits on one screen
+	// Yep, this is a complex validation, but it still fits on one screen
+	@SuppressWarnings("squid:S3776")
 	private Map<MigrationVersion, Element> buildChain0(MigrationContext context, List<Migration> discoveredMigrations,
 			boolean detailedCauses, ChainBuilderMode mode) {
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -32,6 +33,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Values;
 
@@ -72,7 +74,7 @@ final class ChainTool {
 		this.currentElements = currentChain.getElements().stream().collect(collector);
 	}
 
-	static Query generateMigrationDeletionQuery(String migrationTarget, MigrationVersion version) {
+	static Query generateMigrationDeletionQuery(@Nullable String migrationTarget, MigrationVersion version) {
 
 		var cypher = """
 				MATCH (p)-[l:MIGRATED_TO]->(m:__Neo4jMigration {version: $version})
@@ -112,7 +114,7 @@ final class ChainTool {
 		return result;
 	}
 
-	private List<Query> fixChecksums(String migrationTarget) {
+	private List<Query> fixChecksums(@Nullable String migrationTarget) {
 
 		var cypher = """
 				MATCH (m:__Neo4jMigration {version: $version, checksum: $oldChecksum})
@@ -133,14 +135,14 @@ final class ChainTool {
 			.toList();
 	}
 
-	private List<Query> deleteLocallyMissingMigrations(String migrationTarget) {
+	private List<Query> deleteLocallyMissingMigrations(@Nullable String migrationTarget) {
 
 		return findMissingSourceElements().stream()
 			.map(version -> generateMigrationDeletionQuery(migrationTarget, version))
 			.toList();
 	}
 
-	private List<Query> insertRemoteMissingMigrations(String migrationTarget, Optional<String> installedBy) {
+	private List<Query> insertRemoteMissingMigrations(@Nullable String migrationTarget, Optional<String> installedBy) {
 
 		var cypher = """
 				MATCH (pm:__Neo4jMigration {version: $previousVersion}) - [pr:MIGRATED_TO] -> (nm:__Neo4jMigration)
@@ -203,8 +205,9 @@ final class ChainTool {
 		sharedKeys.retainAll(this.currentElements.keySet());
 		return sharedKeys.stream()
 			.collect(Collectors.toMap(Function.identity(),
-					k -> new Pair(this.newElements.get(k), this.currentElements.get(k)), throwingMerger(),
-					() -> new TreeMap<>(this.versionComparator)));
+					k -> new Pair(Objects.requireNonNull(this.newElements.get(k)),
+							Objects.requireNonNull(this.currentElements.get(k))),
+					throwingMerger(), () -> new TreeMap<>(this.versionComparator)));
 	}
 
 	private Set<MigrationVersion> findMissingSourceElements() {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CleanResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CleanResult.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Result of a clean operation. The result is immutable.
  *
@@ -27,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public final class CleanResult implements DatabaseOperationResult {
 
-	private final String affectedDatabase;
+	@Nullable private final String affectedDatabase;
 
 	private final List<String> chainsDeleted;
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ConnectionDetails.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ConnectionDetails.java
@@ -17,6 +17,8 @@ package ac.simons.neo4j.migrations.core;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Provides detailed information about the connection being used when invoking any method
  * that talks to the database.
@@ -38,7 +40,7 @@ public sealed interface ConnectionDetails permits MigrationChain, DefaultConnect
 	 * @since 2.3.0
 	 */
 	static ConnectionDetails of(String serverAddress, String serverVersion, String serverEdition, String userName,
-			String optionalDatabaseName, String optionalSchemaDatabaseName) {
+			@Nullable String optionalDatabaseName, @Nullable String optionalSchemaDatabaseName) {
 		return new DefaultConnectionDetails(serverAddress, serverVersion, serverEdition, userName, optionalDatabaseName,
 				optionalSchemaDatabaseName);
 	}
@@ -51,7 +53,7 @@ public sealed interface ConnectionDetails permits MigrationChain, DefaultConnect
 	/**
 	 * {@return the Neo4j version the server is running}
 	 */
-	String getServerVersion();
+	@Nullable String getServerVersion();
 
 	/**
 	 * {@return the Neo4j edition the server is running}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedCallback.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedCallback.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.SessionConfig;
 
@@ -38,7 +39,7 @@ final class CypherBasedCallback implements Callback {
 
 	private final LifecyclePhase phase;
 
-	private final String description;
+	@Nullable private final String description;
 
 	CypherBasedCallback(ResourceContext context) {
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/CypherBasedMigration.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A cypher script based migration.
@@ -40,7 +41,7 @@ final class CypherBasedMigration extends AbstractCypherBasedMigration implements
 	private List<String> alternativeChecksums = Collections.emptyList();
 
 	@SuppressWarnings("squid:S3077") // This will always be an immutable instance
-	private volatile Optional<String> checksumOfNonePreconditions;
+	@Nullable private volatile Optional<String> checksumOfNonePreconditions;
 
 	CypherBasedMigration(ResourceContext context) {
 		super(CypherResource.of(context));
@@ -62,28 +63,25 @@ final class CypherBasedMigration extends AbstractCypherBasedMigration implements
 				}
 			}
 		}
-		return availableChecksum;
+		return Objects.requireNonNull(availableChecksum, "Checksums could not be initialized");
 	}
 
 	private Optional<String> computeChecksumWithoutPreconditions() {
 
 		// On JDK17 there can be only one, but alas, we aren't there yet.
-		if (!(this.cypherResource instanceof DefaultCypherResource)) {
+		if (!(this.cypherResource instanceof DefaultCypherResource defaultCypherResource)) {
 			return Optional.empty();
 		}
-		List<String> statements = ((DefaultCypherResource) this.cypherResource).getStatements()
-			.stream()
-			.map(statement -> {
-				String quotedPatterns = DefaultCypherResource.getSingleLineComments(statement)
-					.filter(c -> Precondition.parse(c).isPresent())
-					.map(String::trim)
-					.map(Pattern::quote)
-					.collect(Collectors.joining("|"));
+		List<String> statements = defaultCypherResource.getStatements().stream().map(statement -> {
+			String quotedPatterns = DefaultCypherResource.getSingleLineComments(statement)
+				.filter(c -> Precondition.parse(c).isPresent())
+				.map(String::trim)
+				.map(Pattern::quote)
+				.collect(Collectors.joining("|"));
 
-				return quotedPatterns.isEmpty() ? statement
-						: statement.replaceAll("(" + quotedPatterns + ")" + Strings.LINE_DELIMITER, "");
-			})
-			.toList();
+			return quotedPatterns.isEmpty() ? statement
+					: statement.replaceAll("(" + quotedPatterns + ")" + Strings.LINE_DELIMITER, "");
+		}).toList();
 		return Optional.of(DefaultCypherResource.computeChecksum(statements));
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCatalog.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCatalog.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import ac.simons.neo4j.migrations.core.catalog.Catalog;
 import ac.simons.neo4j.migrations.core.catalog.CatalogItem;
 import ac.simons.neo4j.migrations.core.catalog.Name;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default catalog implementation.
@@ -63,9 +64,8 @@ class DefaultCatalog implements WriteableCatalog, VersionedCatalog {
 	public void addAll(MigrationVersion version, Catalog other, boolean reset) {
 
 		WriteLock lock = this.locks.writeLock();
+		lock.lock();
 		try {
-			lock.lock();
-
 			if (reset) {
 				if (this.oldVersions.containsKey(version)) {
 					throw new IllegalArgumentException(
@@ -102,8 +102,8 @@ class DefaultCatalog implements WriteableCatalog, VersionedCatalog {
 	private <T> T withReadLockGet(Supplier<T> s) {
 
 		ReadLock lock = this.locks.readLock();
+		lock.lock();
 		try {
-			lock.lock();
 			return s.get();
 		}
 		finally {
@@ -141,7 +141,11 @@ class DefaultCatalog implements WriteableCatalog, VersionedCatalog {
 	}
 
 	@Override
-	public Optional<CatalogItem<?>> getItemPriorTo(Name name, MigrationVersion version) {
+	public Optional<CatalogItem<?>> getItemPriorTo(@Nullable Name name, @Nullable MigrationVersion version) {
+
+		if (version == null) {
+			return Optional.empty();
+		}
 
 		return withReadLockGet(() -> {
 			Map.Entry<MigrationVersion, VersionedCatalog> oldEntry = this.oldVersions.ceilingEntry(version);
@@ -171,7 +175,11 @@ class DefaultCatalog implements WriteableCatalog, VersionedCatalog {
 	}
 
 	@Override
-	public Optional<CatalogItem<?>> getItem(Name name, MigrationVersion version) {
+	public Optional<CatalogItem<?>> getItem(@Nullable Name name, @Nullable MigrationVersion version) {
+
+		if (version == null) {
+			return Optional.empty();
+		}
 
 		return withReadLockGet(() -> {
 			Map.Entry<MigrationVersion, VersionedCatalog> oldEntry = this.oldVersions.higherEntry(version);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultConnectionDetails.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultConnectionDetails.java
@@ -18,6 +18,7 @@ package ac.simons.neo4j.migrations.core;
 import java.util.Optional;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@link ConnectionDetails}.
@@ -35,12 +36,12 @@ final class DefaultConnectionDetails implements ConnectionDetails {
 
 	private final String username;
 
-	private final String databaseName;
+	@Nullable private final String databaseName;
 
-	private final String schemaDatabaseName;
+	@Nullable private final String schemaDatabaseName;
 
 	DefaultConnectionDetails(String serverAddress, String serverVersion, String edition, String username,
-			String databaseName, String schemaDatabaseName) {
+			@Nullable String databaseName, @Nullable String schemaDatabaseName) {
 		this.serverAddress = serverAddress;
 		this.serverVersion = serverVersion;
 		this.edition = Strings.capitalize(edition);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultCypherResource.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
@@ -44,6 +45,7 @@ import java.util.zip.CRC32;
 import ac.simons.neo4j.migrations.core.MigrationsConfig.CypherVersion;
 import ac.simons.neo4j.migrations.core.internal.Strings;
 import ac.simons.neo4j.migrations.core.refactorings.Counters;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.SimpleQueryRunner;
@@ -128,9 +130,9 @@ final class DefaultCypherResource implements CypherResource {
 	 * locking into an unmodifiable list, see {@link #readStatements()}.
 	 */
 	@SuppressWarnings("squid:S3077")
-	private volatile List<String> statements;
+	@Nullable private volatile List<String> statements;
 
-	private volatile String checksum;
+	@Nullable private volatile String checksum;
 
 	DefaultCypherResource(String identifier, boolean autocrlf, boolean useFlywayCompatibleChecksums,
 			Supplier<InputStream> inputStreamSupplier) {
@@ -142,7 +144,7 @@ final class DefaultCypherResource implements CypherResource {
 	}
 
 	private static String filterBomFromString(String s) {
-		if (s == null || s.isEmpty()) {
+		if (s.isEmpty()) {
 			return s;
 		}
 
@@ -175,7 +177,7 @@ final class DefaultCypherResource implements CypherResource {
 		}
 		boolean notAComment;
 		Stream.Builder<String> builder = Stream.builder();
-		for (String line : statement.split(Strings.LINE_DELIMITER)) {
+		for (String line : statement.split(Strings.LINE_DELIMITER, -1)) {
 			line = line.trim();
 			notAComment = !line.startsWith(Strings.CYPHER_SINGLE_LINE_COMMENT);
 			if (notAComment) {
@@ -412,7 +414,8 @@ final class DefaultCypherResource implements CypherResource {
 	private String flywayCompatChecksum() {
 		final CRC32 crc32 = new CRC32();
 
-		try (var bufferedReader = new BufferedReader(new InputStreamReader(this.inputStreamSupplier.get()), 4096)) {
+		try (var bufferedReader = new BufferedReader(
+				new InputStreamReader(this.inputStreamSupplier.get(), StandardCharsets.UTF_8), 4096)) {
 			String line = bufferedReader.readLine();
 
 			if (line != null) {
@@ -428,7 +431,7 @@ final class DefaultCypherResource implements CypherResource {
 					"Unable to calculate checksum of " + this.identifier + "\r\n" + ex.getMessage(), ex);
 		}
 		// Yeah, this is fucked up, but flyway does that too…
-		return Integer.toString((int) (crc32.getValue()));
+		return Integer.toString((int) crc32.getValue());
 	}
 
 	/**
@@ -443,8 +446,13 @@ final class DefaultCypherResource implements CypherResource {
 	 * @param filter a filter to apply when selecting the statements
 	 * @return a filtered list of statements
 	 */
-	List<String> getStatements(Predicate<String> filter) {
+	List<String> getStatements(@Nullable Predicate<String> filter) {
 
+		List<String> availableStatements = getStatements0();
+		return (filter != null) ? availableStatements.stream().filter(filter).toList() : availableStatements;
+	}
+
+	private List<String> getStatements0() {
 		List<String> availableStatements = this.statements;
 		if (availableStatements == null) {
 			synchronized (this) {
@@ -455,7 +463,7 @@ final class DefaultCypherResource implements CypherResource {
 				}
 			}
 		}
-		return (filter != null) ? availableStatements.stream().filter(filter).toList() : availableStatements;
+		return Objects.requireNonNull(availableStatements, "Statements could not be initialized");
 	}
 
 	/**

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationChain.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationChain.java
@@ -20,6 +20,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Only implementation of a {@link MigrationChain}.
  *
@@ -43,7 +45,7 @@ final class DefaultMigrationChain implements MigrationChain {
 	}
 
 	@Override
-	public String getServerVersion() {
+	@Nullable public String getServerVersion() {
 		return this.connectionDetailsDelegate.getServerVersion();
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationChainElement.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationChainElement.java
@@ -20,8 +20,10 @@ import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.types.IsoDuration;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
@@ -39,18 +41,18 @@ final class DefaultMigrationChainElement implements MigrationChain.Element {
 
 	private final MigrationType type;
 
-	private final String checksum;
+	@Nullable private final String checksum;
 
 	private final String version;
 
-	private final String description;
+	@Nullable private final String description;
 
 	private final String source;
 
-	private final InstallationInfo installationInfo;
+	@Nullable private final InstallationInfo installationInfo;
 
-	private DefaultMigrationChainElement(MigrationState state, MigrationType type, String checksum, String version,
-			String description, String source, InstallationInfo installationInfo) {
+	private DefaultMigrationChainElement(MigrationState state, MigrationType type, @Nullable String checksum,
+			String version, @Nullable String description, String source, @Nullable InstallationInfo installationInfo) {
 		this.state = state;
 		this.type = type;
 		this.checksum = checksum;
@@ -78,10 +80,16 @@ final class DefaultMigrationChainElement implements MigrationChain.Element {
 			.plusNanos(storedExecutionTime.nanoseconds());
 
 		return new DefaultMigrationChainElement(MigrationState.APPLIED,
-				MigrationType.valueOf((String) properties.get("type")),
+				MigrationType.valueOf((String) getNullSafeProperty(properties, "type")),
 				migrationProperties.get("checksum").asString((String) properties.get("checksum")),
-				(String) properties.get("version"), (String) properties.get("description"),
-				(String) properties.get("source"), new InstallationInfo(installedOn, installedBy, executionTime));
+				(String) getNullSafeProperty(properties, "version"), (String) properties.get("description"),
+				(String) getNullSafeProperty(properties, "source"),
+				new InstallationInfo(installedOn, installedBy, executionTime));
+	}
+
+	private static Object getNullSafeProperty(Map<String, Object> properties, String name) {
+		return Objects.requireNonNull(properties.get(name),
+				() -> "Invalid migration node, no '%s' property".formatted(name));
 	}
 
 	static MigrationChain.Element pendingElement(Migration pendingMigration) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationContext.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultMigrationContext.java
@@ -19,9 +19,11 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import ac.simons.neo4j.migrations.core.catalog.Catalog;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.BookmarkManager;
 import org.neo4j.driver.BookmarkManagerConfig;
@@ -47,7 +49,7 @@ import org.neo4j.driver.summary.ServerInfo;
  */
 final class DefaultMigrationContext implements MigrationContext {
 
-	private static final Method WITH_IMPERSONATED_USER = findWithImpersonatedUser();
+	@Nullable private static final Method WITH_IMPERSONATED_USER = findWithImpersonatedUser();
 
 	private final UnaryOperator<SessionConfig.Builder> applySchemaDatabase;
 
@@ -59,8 +61,8 @@ final class DefaultMigrationContext implements MigrationContext {
 
 	private final VersionedCatalog catalog;
 
-	@SuppressWarnings("squid:S3077") // This will always be an immutable instance.s
-	private volatile ConnectionDetails connectionDetails;
+	@SuppressWarnings("squid:S3077") // This will always be an immutable instance.
+	@Nullable private volatile ConnectionDetails connectionDetails;
 
 	DefaultMigrationContext(MigrationsConfig config, Driver driver) {
 
@@ -80,7 +82,7 @@ final class DefaultMigrationContext implements MigrationContext {
 		this.catalog = new DefaultCatalog(config.getVersionComparator());
 	}
 
-	private static Method findWithImpersonatedUser() {
+	@Nullable private static Method findWithImpersonatedUser() {
 		try {
 			return SessionConfig.Builder.class.getMethod("withImpersonatedUser", String.class);
 		}
@@ -91,10 +93,7 @@ final class DefaultMigrationContext implements MigrationContext {
 
 	static void setWithImpersonatedUser(SessionConfig.Builder builder, String user) {
 		try {
-			// This is fine, when an impersonated user is present, the availability of
-			// this method has been checked.
-			// noinspection ConstantConditions
-			WITH_IMPERSONATED_USER.invoke(builder, user);
+			Objects.requireNonNull(WITH_IMPERSONATED_USER).invoke(builder, user);
 		}
 		catch (IllegalAccessException | InvocationTargetException ex) {
 			throw new MigrationsException("Could not impersonate a user on the driver level", ex);
@@ -251,7 +250,7 @@ final class DefaultMigrationContext implements MigrationContext {
 	}
 
 	record ExtendedResultSummary(boolean showCurrentUserExists, String version, String edition, ServerInfo server,
-			DatabaseInfo database) {
+			@Nullable DatabaseInfo database) {
 		ExtendedResultSummary(boolean showCurrentUserExists, String version, String edition,
 				ResultSummary actualSummary) {
 			this(showCurrentUserExists, version, edition, actualSummary.server(), actualSummary.database());

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultRefactoringContext.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DefaultRefactoringContext.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import ac.simons.neo4j.migrations.core.internal.Strings;
 import ac.simons.neo4j.migrations.core.refactorings.QueryRunner;
 import ac.simons.neo4j.migrations.core.refactorings.RefactoringContext;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
@@ -53,13 +54,13 @@ final class DefaultRefactoringContext implements RefactoringContext {
 
 	private final Supplier<Session> sessionSupplier;
 
-	private volatile Neo4jVersion version;
+	@Nullable private volatile Neo4jVersion version;
 
 	DefaultRefactoringContext(Supplier<Session> sessionSupplier) {
 		this(sessionSupplier, null);
 	}
 
-	DefaultRefactoringContext(Supplier<Session> sessionSupplier, Neo4jVersion neo4jVersion) {
+	DefaultRefactoringContext(Supplier<Session> sessionSupplier, @Nullable Neo4jVersion neo4jVersion) {
 		this.sessionSupplier = sessionSupplier;
 		this.version = neo4jVersion;
 	}
@@ -75,8 +76,8 @@ final class DefaultRefactoringContext implements RefactoringContext {
 			return false;
 		}
 
-		Predicate<String> nullOrBlank = s -> s == null || s.trim().isEmpty();
-		Predicate<String> isExactlyDetails = s -> details.asString().equals(s);
+		Predicate<@Nullable String> nullOrBlank = s -> s == null || s.trim().isEmpty();
+		Predicate<@Nullable String> isExactlyDetails = s -> details.asString().equals(s);
 
 		return plan.identifiers().stream().filter(nullOrBlank.negate().and(isExactlyDetails)).count() == 1L;
 	}
@@ -152,7 +153,7 @@ final class DefaultRefactoringContext implements RefactoringContext {
 		try (Session session = this.sessionSupplier.get()) {
 			ResultSummary resultSummary = session.executeRead(tx -> tx.run(new Query("EXPLAIN " + query)).consume());
 			Plan root = resultSummary.plan();
-			if (isProduceResultOperator(root) && hasSingleElement(root)) {
+			if (isProduceResultOperator(root) && hasSingleElement(root) && root.arguments().containsKey(KEY_DETAILS)) {
 				return Optional.of(root.arguments().get(KEY_DETAILS).asString());
 			}
 		}
@@ -161,7 +162,7 @@ final class DefaultRefactoringContext implements RefactoringContext {
 	}
 
 	@Override
-	public String sanitizeSchemaName(String potentiallyNonIdentifier) {
+	@Nullable public String sanitizeSchemaName(String potentiallyNonIdentifier) {
 		return this.getVersion().sanitizeSchemaName(potentiallyNonIdentifier);
 	}
 
@@ -169,7 +170,7 @@ final class DefaultRefactoringContext implements RefactoringContext {
 
 		private final Session session;
 
-		private final Transaction transaction;
+		@Nullable private final Transaction transaction;
 
 		private final UnaryOperator<Query> filter;
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DeleteResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DeleteResult.java
@@ -17,6 +17,8 @@ package ac.simons.neo4j.migrations.core;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link DeleteResult} will be created after using
  * {@link Migrations#delete(MigrationVersion)} for deleting one single migration. It
@@ -28,10 +30,10 @@ import java.util.Optional;
  */
 public final class DeleteResult extends AbstractRepairmentResult {
 
-	private final MigrationVersion version;
+	@Nullable private final MigrationVersion version;
 
-	DeleteResult(String affectedDatabase, long nodesDeleted, long nodesCreated, long relationshipsDeleted,
-			long relationshipsCreated, long propertiesSet, MigrationVersion version) {
+	DeleteResult(@Nullable String affectedDatabase, long nodesDeleted, long nodesCreated, long relationshipsDeleted,
+			long relationshipsCreated, long propertiesSet, @Nullable MigrationVersion version) {
 		super(affectedDatabase, nodesDeleted, nodesCreated, relationshipsDeleted, relationshipsCreated, propertiesSet);
 		this.version = version;
 	}
@@ -51,6 +53,7 @@ public final class DeleteResult extends AbstractRepairmentResult {
 	}
 
 	@Override
+	@SuppressWarnings({ "NullAway", "DataFlowIssue" })
 	public String prettyPrint() {
 
 		if (!isDatabaseChanged()) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
@@ -104,11 +104,11 @@ final class DiscoveryService {
 		});
 
 		migrations.forEach(m -> {
-			if (migrationsAndPreconditions.get(m).isEmpty()) {
+			if (!migrationsAndPreconditions.containsKey(m) || migrationsAndPreconditions.get(m).isEmpty()) {
 				return;
 			}
 			List<String> alternativeChecksums = migrations.stream()
-				.filter(o -> o != m && o.getSource().equals(m.getSource())
+				.filter(o -> o != m && o.getSource().equals(m.getSource()) && migrationsAndPreconditions.containsKey(o)
 						&& !migrationsAndPreconditions.get(o).isEmpty())
 				.flatMap(o -> {
 					Stream<String> checksum = o.getChecksum().stream();
@@ -122,7 +122,7 @@ final class DiscoveryService {
 	boolean hasUnmetPreconditions(Map<Migration, List<Precondition>> migrationsAndPreconditions, Migration migration,
 			MigrationContext context) {
 
-		if (!(migration instanceof MigrationWithPreconditions)) {
+		if (!(migration instanceof MigrationWithPreconditions && migrationsAndPreconditions.containsKey(migration))) {
 			return false;
 		}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/HBD.java
@@ -16,12 +16,14 @@
 package ac.simons.neo4j.migrations.core;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
 import ac.simons.neo4j.migrations.core.internal.Neo4jVersionComparator;
 import ac.simons.neo4j.migrations.core.refactorings.Counters;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.Neo4jException;
@@ -53,7 +55,7 @@ final class HBD {
 	}
 
 	static Integer silentCreateConstraintOrIndex(ConnectionDetails connectionDetails, Session session, String statement,
-			String name, Supplier<String> failureMessage) {
+			@Nullable String name, Supplier<String> failureMessage) {
 
 		String finalStatement;
 		String replacement = "";
@@ -69,7 +71,7 @@ final class HBD {
 		catch (Neo4jException ex) {
 			var expectedMessages = Set.of("Invalid constraint syntax, ON and ASSERT should not be used",
 					"Invalid input 'ON'", "Invalid input '(': expected 'IF NOT EXISTS' or 'FOR'");
-			if (Neo4jCodes.SYNTAX_ERROR.equals(ex.code())
+			if (Neo4jCodes.SYNTAX_ERROR.equals(ex.code()) && ex.getMessage() != null
 					&& expectedMessages.stream().anyMatch(m -> ex.getMessage().startsWith(m))) {
 				// This should by all means not happen, since this method is used outside
 				// testing only with proper rendered constraints
@@ -86,7 +88,7 @@ final class HBD {
 	}
 
 	static Integer silentDropConstraint(ConnectionDetails connectionDetails, Session session, String statement,
-			String name) {
+			@Nullable String name) {
 
 		String finalStatement;
 		if ((is4xSeries(connectionDetails) || Neo4jVersion.of(connectionDetails.getServerVersion()).is5OrHigher())
@@ -144,7 +146,7 @@ final class HBD {
 			return false;
 		}
 
-		return e.getMessage()
+		return Objects.requireNonNullElse(e.getMessage(), "")
 			.toLowerCase(Locale.ROOT)
 			.contains("constraint requires Neo4j Enterprise Edition".toLowerCase(Locale.ROOT));
 	}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/IterableMigrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/IterableMigrations.java
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 import java.util.logging.Level;
 
 import ac.simons.neo4j.migrations.core.MigrationVersion.StopVersion;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A helper class that can be used to delay the iteration of migrations by a configurable
@@ -37,9 +38,10 @@ final class IterableMigrations implements Iterable<Migration> {
 
 	private final List<Migration> migrations;
 
-	private final MigrationVersion optionalStop;
+	@Nullable private final MigrationVersion optionalStop;
 
-	private IterableMigrations(MigrationsConfig config, List<Migration> migrations, MigrationVersion optionalStop) {
+	private IterableMigrations(MigrationsConfig config, List<Migration> migrations,
+			@Nullable MigrationVersion optionalStop) {
 		this.config = config;
 		this.migrations = migrations;
 		this.optionalStop = optionalStop;
@@ -49,7 +51,8 @@ final class IterableMigrations implements Iterable<Migration> {
 		return of(config, migrations, null);
 	}
 
-	static IterableMigrations of(MigrationsConfig config, List<Migration> migrations, StopVersion stopVersion) {
+	static IterableMigrations of(MigrationsConfig config, List<Migration> migrations,
+			@Nullable StopVersion stopVersion) {
 		MigrationVersion optionalStop;
 		if (stopVersion == null) {
 			optionalStop = null;
@@ -78,16 +81,16 @@ final class IterableMigrations implements Iterable<Migration> {
 
 		private final Iterator<Migration> delegate;
 
-		private final Duration optionalDelay;
+		@Nullable private final Duration optionalDelay;
 
 		private final Comparator<MigrationVersion> comparator;
 
-		private final MigrationVersion optionalStop;
+		@Nullable private final MigrationVersion optionalStop;
 
-		private Migration next;
+		@Nullable private Migration next;
 
-		DelayingIterator(Iterator<Migration> delegate, Duration optionalDelay, Comparator<MigrationVersion> comparator,
-				MigrationVersion optionalStop) {
+		DelayingIterator(Iterator<Migration> delegate, @Nullable Duration optionalDelay,
+				Comparator<MigrationVersion> comparator, @Nullable MigrationVersion optionalStop) {
 			this.delegate = delegate;
 			this.optionalDelay = optionalDelay;
 			this.comparator = comparator;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/JavaBasedMigration.java
@@ -69,6 +69,7 @@ public non-sealed interface JavaBasedMigration extends Migration {
 	 * @return {@literal true} if this is a repeatable migration
 	 * @since 2.0.0
 	 */
+	@Override
 	default boolean isRepeatable() {
 		return getVersion().isRepeatable();
 	}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationVersion.java
@@ -17,10 +17,13 @@ package ac.simons.neo4j.migrations.core;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * A migrations version.
@@ -44,7 +47,7 @@ public final class MigrationVersion {
 
 	private final String value;
 
-	private final String description;
+	@Nullable private final String description;
 
 	/**
 	 * A flag indicating that this version can be safely repeated, even on checksum
@@ -53,7 +56,7 @@ public final class MigrationVersion {
 	 */
 	private final boolean repeatable;
 
-	private MigrationVersion(String value, String description, boolean repeatable) {
+	private MigrationVersion(String value, @Nullable String description, boolean repeatable) {
 		this.value = value;
 		this.description = description;
 		this.repeatable = repeatable;
@@ -101,14 +104,14 @@ public final class MigrationVersion {
 	 * @return an optional version to stop migrating at
 	 * @since 2.15.0
 	 */
-	static Optional<StopVersion> findTargetVersion(MigrationChain chain, String value) {
+	static Optional<StopVersion> findTargetVersion(MigrationChain chain, @Nullable String value) {
 
 		if (value == null) {
 			return Optional.empty();
 		}
 
 		try {
-			var upperCaseValue = value.trim().toUpperCase();
+			var upperCaseValue = value.trim().toUpperCase(Locale.ROOT);
 			boolean optional;
 			if (!upperCaseValue.endsWith("?")) {
 				optional = false;
@@ -164,7 +167,7 @@ public final class MigrationVersion {
 		return withValueAndDescription(value, null, repeatable);
 	}
 
-	static MigrationVersion withValueAndDescription(String value, String description, boolean repeatable) {
+	static MigrationVersion withValueAndDescription(String value, @Nullable String description, boolean repeatable) {
 
 		if (BASELINE_VALUE.equals(value)) {
 			return MigrationVersion.baseline();

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -43,6 +43,7 @@ import ac.simons.neo4j.migrations.core.catalog.RenderConfig;
 import ac.simons.neo4j.migrations.core.catalog.Renderer;
 import ac.simons.neo4j.migrations.core.refactorings.Counters;
 import ac.simons.neo4j.migrations.core.refactorings.Refactoring;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
@@ -96,10 +97,10 @@ public final class Migrations {
 	private final AtomicBoolean beforeFirstUseHasBeenCalled = new AtomicBoolean(false);
 
 	@SuppressWarnings("squid:S3077")
-	private volatile List<Migration> resolvedMigrations;
+	@Nullable private volatile List<Migration> resolvedMigrations;
 
 	@SuppressWarnings("squid:S3077")
-	private volatile Map<LifecyclePhase, List<Callback>> resolvedCallbacks;
+	@Nullable private volatile Map<LifecyclePhase, List<Callback>> resolvedCallbacks;
 
 	/**
 	 * Creates a {@link Migrations migrations instance} ready to used with the given
@@ -726,8 +727,8 @@ public final class Migrations {
 		}, null, null, true);
 	}
 
-	private <T> T executeWithinLock(Supplier<T> executable, LifecyclePhase before, LifecyclePhase after,
-			boolean doLock) {
+	private <T> T executeWithinLock(Supplier<T> executable, @Nullable LifecyclePhase before,
+			@Nullable LifecyclePhase after, boolean doLock) {
 
 		this.driver.verifyConnectivity();
 
@@ -764,7 +765,7 @@ public final class Migrations {
 	 * Invokes callbacks.
 	 * @param phase can be {@literal null}, no callback will be involved then
 	 */
-	private void invokeCallbacks(LifecyclePhase phase) {
+	private void invokeCallbacks(@Nullable LifecyclePhase phase) {
 
 		if (phase == null) {
 			return;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsConfig.java
@@ -29,6 +29,7 @@ import java.util.logging.Logger;
 
 import ac.simons.neo4j.migrations.core.catalog.RenderConfig;
 import ac.simons.neo4j.migrations.core.internal.Strings;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.summary.DatabaseInfo;
@@ -50,14 +51,14 @@ public final class MigrationsConfig {
 	/**
 	 * The database to migrate.
 	 */
-	private final String database;
+	private final @Nullable String database;
 
 	/**
 	 * The database to store the schema in.
 	 */
-	private final String schemaDatabase;
+	private final @Nullable String schemaDatabase;
 
-	private final String impersonatedUser;
+	private final @Nullable String impersonatedUser;
 
 	private final String installedBy;
 
@@ -72,17 +73,17 @@ public final class MigrationsConfig {
 	/**
 	 * A configurable delay that will be applied in between applying two migrations.
 	 */
-	private final Duration delayBetweenMigrations;
+	private final @Nullable Duration delayBetweenMigrations;
 
 	private final List<? extends RenderConfig.AdditionalRenderingOptions> constraintOptions;
 
 	private final VersionSortOrder versionSortOrder;
 
-	private final Duration transactionTimeout;
+	private final @Nullable Duration transactionTimeout;
 
 	private final boolean outOfOrder;
 
-	private final String target;
+	private final @Nullable String target;
 
 	private final boolean useFlywayCompatibleChecksums;
 
@@ -268,10 +269,10 @@ public final class MigrationsConfig {
 	/**
 	 * Returns the transaction timeout, <code>null</code> indicates all transactions will
 	 * use the drivers default timeout.
-	 * @return the transaction tineout
+	 * @return the transaction timeout
 	 * @since 2.13.0
 	 */
-	public Duration getTransactionTimeout() {
+	public @Nullable Duration getTransactionTimeout() {
 		return this.transactionTimeout;
 	}
 
@@ -290,7 +291,7 @@ public final class MigrationsConfig {
 	 * {@return a valid target version or one of three dedicated values}
 	 * @since 2.15.0
 	 */
-	public String getTarget() {
+	public @Nullable String getTarget() {
 		return this.target;
 	}
 
@@ -495,52 +496,51 @@ public final class MigrationsConfig {
 	 */
 	public static final class Builder {
 
-		private String[] packagesToScan;
+		private String @Nullable [] packagesToScan;
 
-		private String[] locationsToScan;
+		private String @Nullable [] locationsToScan;
 
-		private TransactionMode transactionMode;
+		private @Nullable TransactionMode transactionMode;
 
-		private String database;
+		private @Nullable String database;
 
-		private String impersonatedUser;
+		private @Nullable String impersonatedUser;
 
-		private String installedBy;
+		private @Nullable String installedBy;
 
 		private boolean validateOnMigrate = Defaults.VALIDATE_ON_MIGRATE;
 
 		private boolean autocrlf = Defaults.AUTOCRLF;
 
-		private String schemaDatabase;
+		private @Nullable String schemaDatabase;
 
-		private Discoverer<JavaBasedMigration> migrationClassesDiscoverer;
+		private @Nullable Discoverer<JavaBasedMigration> migrationClassesDiscoverer;
 
-		private ClasspathResourceScanner resourceScanner;
+		private @Nullable ClasspathResourceScanner resourceScanner;
 
-		private Duration delayBetweenMigrations;
+		private @Nullable Duration delayBetweenMigrations;
 
 		private List<? extends RenderConfig.AdditionalRenderingOptions> constraintOptions = List.of();
 
 		private VersionSortOrder versionSortOrder = Defaults.VERSION_SORT_ORDER;
 
-		private Duration transactionTimeout;
+		private @Nullable Duration transactionTimeout;
 
 		private boolean outOfOrder = Defaults.OUT_OF_ORDER;
 
-		private String target;
+		private @Nullable String target;
 
 		private boolean useFlywayCompatibleChecksums = Defaults.USE_FLYWAY_COMPATIBLE_CHECKSUMS;
 
-		private CypherVersion cypherVersion = Defaults.CYPHER_VERSION;
+		private @Nullable CypherVersion cypherVersion = Defaults.CYPHER_VERSION;
 
-		private Map<String, String> placeholders;
+		private @Nullable Map<String, String> placeholders;
 
 		private Builder() {
 			// The explicit constructor has been added to avoid warnings when
-			// Neo4j-Migrations
-			// is used on the module path. JMS will complain about Builder being exported
-			// with
-			// a public visible, implicit constructor.
+			// Neo4j-Migrations is used on the module path. JMS will complain
+			// about Builder being exported with a public visible,
+			// implicit constructor.
 		}
 
 		/**
@@ -611,7 +611,7 @@ public final class MigrationsConfig {
 		 * the ones available locally and is on by default. It can be turned off by using
 		 * a configuration with {@link MigrationsConfig#isValidateOnMigrate()} to
 		 * {@literal false}.
-		 * @param newValidateOnMigrate the new value for {@code validateOnMigrate}.
+		 * @param newValidateOnMigrate the new value for <code>validateOnMigrate</code>
 		 * @return the builder for further customization
 		 * @since 0.2.1
 		 */
@@ -802,7 +802,7 @@ public final class MigrationsConfig {
 		 * @return the builder for further customization
 		 * @since 2.19.0
 		 */
-		public Builder withCypherVersion(CypherVersion newCypherVersion) {
+		public Builder withCypherVersion(@Nullable CypherVersion newCypherVersion) {
 			this.cypherVersion = newCypherVersion;
 			return this;
 		}
@@ -817,7 +817,7 @@ public final class MigrationsConfig {
 		 * @return the builder for further customization
 		 * @since 3.3.0
 		 */
-		public Builder withPlaceholders(Map<String, String> newPlaceholders) {
+		public Builder withPlaceholders(@Nullable Map<String, String> newPlaceholders) {
 			this.placeholders = (newPlaceholders != null) ? Map.copyOf(newPlaceholders) : null;
 			return this;
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsLock.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsLock.java
@@ -101,7 +101,7 @@ final class MigrationsLock {
 		var translation = Map.of(Constraint.Type.UNIQUE, "UNIQUENESS", Constraint.Type.KEY, "NODE_KEY");
 
 		String cypher = CONSTRAINT_RENDERER.render(constraint, dropConfig);
-		Integer constraintsDropped = HBD.silentDropConstraint(cd, session, cypher, null);
+		var constraintsDropped = HBD.silentDropConstraint(cd, session, cypher, null);
 		if (constraintsDropped == 0) {
 			// Enforce unnamed
 			cypher = CONSTRAINT_RENDERER.render(constraint, dropConfig.ignoreName());

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Neo4jVersion.java
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 
 /**
@@ -117,7 +118,7 @@ public enum Neo4jVersion {
 	 * @param version a version string
 	 * @return a version
 	 */
-	public static Neo4jVersion of(String version) {
+	public static Neo4jVersion of(@Nullable String version) {
 
 		String value = (version != null) ? version.replaceFirst("(?i)Neo4j[/:]", "") : null;
 		if (value == null) {
@@ -244,7 +245,7 @@ public enum Neo4jVersion {
 		if (this == LATEST || this == UNDEFINED) {
 			return -1;
 		}
-		String[] parts = this.name().split("_");
+		String[] parts = this.name().split("_", -1);
 		if (parts.length != 2) {
 			return -1;
 		}
@@ -254,12 +255,12 @@ public enum Neo4jVersion {
 	/**
 	 * Escapes the string {@literal potentiallyNonIdentifier} in all cases when it's not a
 	 * valid Cypher identifier, fitting the given version.
-	 * @param potentiallyNonIdentifier a value to escape, must not be {@literal null} or
-	 * blank
+	 * @param potentiallyNonIdentifier a value to escape; the same value will be returned
+	 * if {@literal null} or empty
 	 * @return the sanitized and quoted value or the same value if no change is necessary.
 	 * @since 1.11.0
 	 */
-	public String sanitizeSchemaName(String potentiallyNonIdentifier) {
+	@Nullable public String sanitizeSchemaName(@Nullable String potentiallyNonIdentifier) {
 
 		if (potentiallyNonIdentifier == null || potentiallyNonIdentifier.isEmpty()) {
 			return potentiallyNonIdentifier;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductVersion.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ProductVersion.java
@@ -18,8 +18,11 @@ package ac.simons.neo4j.migrations.core;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class to retrieve the version of the core module aka the product version.
@@ -29,7 +32,7 @@ import java.util.jar.Manifest;
  */
 final class ProductVersion {
 
-	private static volatile String value;
+	@Nullable private static volatile String value;
 
 	private ProductVersion() {
 	}
@@ -46,7 +49,7 @@ final class ProductVersion {
 				}
 			}
 		}
-		return computedVersion;
+		return Objects.requireNonNull(computedVersion, "Product version could not be initialized");
 	}
 
 	private static String getVersionImpl() {
@@ -57,7 +60,7 @@ final class ProductVersion {
 				Manifest manifest = new Manifest(url.openStream());
 				if (isApplicableManifest(manifest)) {
 					Attributes attr = manifest.getMainAttributes();
-					return get(attr, "Implementation-Version").toString();
+					return Objects.requireNonNull(get(attr, "Implementation-Version")).toString();
 				}
 			}
 		}
@@ -73,7 +76,7 @@ final class ProductVersion {
 		return "neo4j-migrations".equals(get(attributes, "Artifact-Id"));
 	}
 
-	private static Object get(Attributes attributes, String key) {
+	@Nullable private static Object get(Attributes attributes, String key) {
 		return attributes.get(new Attributes.Name(key));
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/RepairmentResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/RepairmentResult.java
@@ -15,6 +15,8 @@
  */
 package ac.simons.neo4j.migrations.core;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link RepairmentResult} will be available after a successful attempt of repairing a
  * database. An attempt is considered successful no repairing was necessary or all errors
@@ -27,17 +29,17 @@ public final class RepairmentResult extends AbstractRepairmentResult {
 
 	private final Outcome outcome;
 
-	private RepairmentResult(String affectedDatabase, long nodesDeleted, long nodesCreated, long relationshipsDeleted,
-			long relationshipsCreated, long propertiesSet, Outcome outcome) {
+	private RepairmentResult(@Nullable String affectedDatabase, long nodesDeleted, long nodesCreated,
+			long relationshipsDeleted, long relationshipsCreated, long propertiesSet, Outcome outcome) {
 		super(affectedDatabase, nodesDeleted, nodesCreated, relationshipsDeleted, relationshipsCreated, propertiesSet);
 		this.outcome = outcome;
 	}
 
-	static RepairmentResult unnecessary(String affectedDatabase) {
+	static RepairmentResult unnecessary(@Nullable String affectedDatabase) {
 		return new RepairmentResult(affectedDatabase, 0, 0, 0, 0, 0, Outcome.NO_REPAIRMENT_NECESSARY);
 	}
 
-	static RepairmentResult repaired(String affectedDatabase, long nodesDeleted, long nodesCreated,
+	static RepairmentResult repaired(@Nullable String affectedDatabase, long nodesDeleted, long nodesCreated,
 			long relationshipsDeleted, long relationshipsCreated, long propertiesSet) {
 		return new RepairmentResult(affectedDatabase, nodesDeleted, nodesCreated, relationshipsDeleted,
 				relationshipsCreated, propertiesSet, Outcome.REPAIRED);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ValidationResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ValidationResult.java
@@ -25,6 +25,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The result of the {@link Migrations#validate} operation.
  *
@@ -36,7 +38,7 @@ public final class ValidationResult implements DatabaseOperationResult {
 	private static final Set<Outcome> NEEDS_REPAIR = EnumSet.of(Outcome.INCOMPLETE_MIGRATIONS,
 			Outcome.DIFFERENT_CONTENT, Outcome.UNDEFINED);
 
-	private final String affectedDatabase;
+	@Nullable private final String affectedDatabase;
 
 	private final Outcome outcome;
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/VersionPrecondition.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/VersionPrecondition.java
@@ -84,7 +84,7 @@ final class VersionPrecondition extends AbstractPrecondition implements Precondi
 			rawVersions = rawVersions.replace("or", ",");
 
 			Set<String> formattedVersions = new TreeSet<>();
-			for (String rawVersion : rawVersions.split(",")) {
+			for (String rawVersion : rawVersions.split(",", -1)) {
 				String version = rawVersion.trim();
 				if (!VERSION_SUB_PATTERN.matcher(version).matches()) {
 					throw new IllegalArgumentException();
@@ -104,7 +104,7 @@ final class VersionPrecondition extends AbstractPrecondition implements Precondi
 	public boolean isMet(MigrationContext migrationContext) {
 		String serverVersion = migrationContext.getConnectionDetails().getServerVersion();
 		if (this.mode == Mode.EXACT) {
-			return this.versions.stream().anyMatch(serverVersion::startsWith);
+			return serverVersion != null && this.versions.stream().anyMatch(serverVersion::startsWith);
 		}
 		else {
 			return this.versions.stream().findFirst().map(version -> {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/VersionedCatalog.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/VersionedCatalog.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import ac.simons.neo4j.migrations.core.catalog.Catalog;
 import ac.simons.neo4j.migrations.core.catalog.CatalogItem;
 import ac.simons.neo4j.migrations.core.catalog.Name;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An extended catalog keeping track of items as defined by {@link CatalogBasedMigration
@@ -65,7 +66,7 @@ public interface VersionedCatalog extends Catalog {
 	 * @return an optional item as defined prior to the introduction of {@literal version}
 	 */
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
-	Optional<CatalogItem<?>> getItemPriorTo(Name name, MigrationVersion version);
+	Optional<CatalogItem<?>> getItemPriorTo(@Nullable Name name, @Nullable MigrationVersion version);
 
 	/**
 	 * A list of all items up to and including a given version.
@@ -83,6 +84,6 @@ public interface VersionedCatalog extends Catalog {
 	 * @return an optional item as defined with to the introduction of {@literal version}
 	 */
 	@SuppressWarnings("squid:S1452") // Generic items, this is exactly what we want here
-	Optional<CatalogItem<?>> getItem(Name name, MigrationVersion version);
+	Optional<CatalogItem<?>> getItem(@Nullable Name name, @Nullable MigrationVersion version);
 
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/AbstractCatalogItem.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/AbstractCatalogItem.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
 import ac.simons.neo4j.migrations.core.internal.XMLSchemaConstants;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.types.MapAccessor;
 import org.neo4j.driver.types.TypeSystem;
@@ -47,7 +48,7 @@ abstract non-sealed class AbstractCatalogItem<T extends ItemType> implements Cat
 	/**
 	 * Any additional options to be passed to the item. Might be {@literal null}.
 	 */
-	protected final String options;
+	@Nullable protected final String options;
 
 	/**
 	 * The unique name of this item.
@@ -75,8 +76,8 @@ abstract non-sealed class AbstractCatalogItem<T extends ItemType> implements Cat
 	 */
 	private final Set<String> properties;
 
-	AbstractCatalogItem(String name, T type, TargetEntityType targetEntityType, String identifier,
-			Collection<String> properties, String options) {
+	AbstractCatalogItem(@Nullable String name, T type, TargetEntityType targetEntityType, String identifier,
+			Collection<String> properties, @Nullable String options) {
 
 		if (properties.isEmpty() && type != Index.Type.LOOKUP) {
 			throw new IllegalArgumentException("Constraints or indices require one or more properties.");
@@ -170,7 +171,7 @@ abstract non-sealed class AbstractCatalogItem<T extends ItemType> implements Cat
 	 * @param constraintElement the element to extract options from
 	 * @return optional options
 	 */
-	static String extractOptions(Element constraintElement) {
+	@Nullable static String extractOptions(Element constraintElement) {
 		NodeList optionsElement = constraintElement.getElementsByTagName(XMLSchemaConstants.OPTIONS);
 		String options = null;
 		if (optionsElement.getLength() == 1) {
@@ -230,10 +231,9 @@ abstract non-sealed class AbstractCatalogItem<T extends ItemType> implements Cat
 		if (this == o) {
 			return true;
 		}
-		if (o == null || getClass() != o.getClass()) {
+		if (!(o instanceof AbstractCatalogItem<?> that)) {
 			return false;
 		}
-		AbstractCatalogItem<?> that = (AbstractCatalogItem<?>) o;
 		return getName().equals(that.getName()) && getOptionalOptions().equals(that.getOptionalOptions())
 				&& isEquivalentTo(that);
 	}
@@ -275,7 +275,7 @@ abstract non-sealed class AbstractCatalogItem<T extends ItemType> implements Cat
 			Element newElement = document.createElement(XMLSchemaConstants.PROPERTY);
 			newElement.setTextContent(propertyValue);
 			if (this instanceof Constraint constraint && constraint.getType() == Constraint.Type.PROPERTY_TYPE) {
-				newElement.setAttribute("type", constraint.getPropertyType().getName());
+				newElement.setAttribute("type", Objects.requireNonNull(constraint.getPropertyType()).getName());
 			}
 			propertiesParentElement.appendChild(newElement);
 		}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/AbstractName.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/AbstractName.java
@@ -17,6 +17,8 @@ package ac.simons.neo4j.migrations.core.catalog;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Value holder for a names value. Default and generated names are different classes on
  * purpose, even though they could be the same one, with the generator on the interface.
@@ -29,26 +31,22 @@ abstract non-sealed class AbstractName implements Name {
 	/**
 	 * Value of this name, might be {@literal null} or blank.
 	 */
-	private final String value;
+	@Nullable private final String value;
 
-	AbstractName(String value) {
+	AbstractName(@Nullable String value) {
 		this.value = value;
 	}
 
 	@Override
-	public String getValue() {
+	@Nullable public String getValue() {
 		return this.value;
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
+		if (!(o instanceof AbstractName that)) {
 			return false;
 		}
-		AbstractName that = (AbstractName) o;
 		return Objects.equals(this.value, that.value);
 	}
 
@@ -59,7 +57,7 @@ abstract non-sealed class AbstractName implements Name {
 
 	@Override
 	public String toString() {
-		return this.value;
+		return Objects.requireNonNull(this.value, super::toString);
 	}
 
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/CatalogItem.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/CatalogItem.java
@@ -18,6 +18,8 @@ package ac.simons.neo4j.migrations.core.catalog;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * An item in the catalog (of either a single migration or the whole context with the
  * merged catalog).
@@ -59,7 +61,7 @@ public sealed interface CatalogItem<T extends ItemType> permits AbstractCatalogI
 	 * @return a (potentially) new item
 	 * @since 1.13.0
 	 */
-	default CatalogItem<T> withName(String name) {
+	default CatalogItem<T> withName(@Nullable String name) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Constraint.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Constraint.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import ac.simons.neo4j.migrations.core.internal.XMLSchemaConstants;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.MapAccessor;
@@ -62,27 +63,27 @@ public final class Constraint extends AbstractCatalogItem<Constraint.Type> {
 	private static final Set<String> REQUIRED_KEYS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("name",
 			XMLSchemaConstants.TYPE, "entityType", "labelsOrTypes", XMLSchemaConstants.PROPERTIES)));
 
-	private final PropertyType propertyType;
+	@Nullable private final PropertyType propertyType;
 
 	Constraint(Type type, TargetEntityType targetEntityType, String identifier, Collection<String> properties,
 			PropertyType propertyType) {
 		this(null, type, targetEntityType, identifier, properties, null, propertyType);
 	}
 
-	Constraint(String name, Type type, TargetEntityType targetEntityType, String identifier,
-			Collection<String> properties, PropertyType propertyType) {
+	Constraint(@Nullable String name, Type type, TargetEntityType targetEntityType, String identifier,
+			Collection<String> properties, @Nullable PropertyType propertyType) {
 		this(name, type, targetEntityType, identifier, properties, null, propertyType);
 	}
 
-	Constraint(String name, Type type, TargetEntityType targetEntityType, String identifier,
-			Collection<String> properties, String options, PropertyType propertyType) {
+	Constraint(@Nullable String name, Type type, TargetEntityType targetEntityType, String identifier,
+			Collection<String> properties, @Nullable String options, @Nullable PropertyType propertyType) {
 		super(name, type, targetEntityType, identifier, properties, options);
 
 		if (type == Type.KEY && getTargetEntityType() != TargetEntityType.NODE) {
 			throw new IllegalArgumentException("Key constraints are only supported for nodes, not for relationships.");
 		}
 
-		if (propertyType != null && type != Type.PROPERTY_TYPE) {
+		if (type != Type.PROPERTY_TYPE && propertyType != null) {
 			throw new IllegalArgumentException("A property type can only be used with a property type constraint.");
 		}
 		if (type == Type.PROPERTY_TYPE && propertyType == null) {
@@ -204,7 +205,7 @@ public final class Constraint extends AbstractCatalogItem<Constraint.Type> {
 	 * @param name an optional name, might be {@literal null}
 	 * @return the new constraint if the description is parseable
 	 */
-	private static Constraint parse(String description, String name) {
+	private static Constraint parse(String description, @Nullable String name) {
 
 		for (PatternHolder patternHolder : new PatternHolder[] { PATTERN_NODE_PROPERTY_IS_UNIQUE,
 				PATTERN_NODE_PROPERTY_EXISTS, PATTERN_NODE_KEY, PATTERN_REL_PROPERTY_EXISTS }) {
@@ -247,7 +248,7 @@ public final class Constraint extends AbstractCatalogItem<Constraint.Type> {
 
 	@Override
 	@SuppressWarnings("HiddenField")
-	public Constraint withName(String name) {
+	public Constraint withName(@Nullable String name) {
 
 		if (Objects.equals(super.getName().getValue(), name)) {
 			return this;
@@ -260,7 +261,7 @@ public final class Constraint extends AbstractCatalogItem<Constraint.Type> {
 	/**
 	 * {@return the data type of the property being constrained}
 	 */
-	public PropertyType getPropertyType() {
+	@Nullable public PropertyType getPropertyType() {
 		return this.propertyType;
 	}
 
@@ -420,7 +421,7 @@ public final class Constraint extends AbstractCatalogItem<Constraint.Type> {
 
 		private final String identifier;
 
-		private String name;
+		@Nullable private String name;
 
 		private DefaultBuilder(TargetEntityType targetEntityType, String identifier) {
 			this.targetEntityType = targetEntityType;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/ConstraintToCypherRenderer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/ConstraintToCypherRenderer.java
@@ -23,6 +23,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Formattable;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -258,7 +259,8 @@ enum ConstraintToCypherRenderer implements Renderer<Constraint> {
 		String properties = renderProperties(version, variable, constraint);
 
 		return String.format("CREATE %#s %sFOR " + templateFragment + " REQUIRE %s IS :: %s", item,
-				config.ifNotExistsOrEmpty(), variable, identifier, properties, constraint.getPropertyType().getName());
+				config.ifNotExistsOrEmpty(), variable, identifier, properties,
+				Objects.requireNonNull(constraint.getPropertyType()).getName());
 	}
 
 	private String renderUniqueConstraint(Constraint constraint, RenderConfig config) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/DefaultName.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/DefaultName.java
@@ -15,6 +15,8 @@
  */
 package ac.simons.neo4j.migrations.core.catalog;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Default implementation of a {@link Name}.
  *
@@ -25,7 +27,7 @@ final class DefaultName extends AbstractName {
 
 	static final DefaultName EMPTY = new DefaultName(null);
 
-	DefaultName(String value) {
+	DefaultName(@Nullable String value) {
 		super(value);
 	}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Index.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Index.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
 import ac.simons.neo4j.migrations.core.internal.XMLSchemaConstants;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.types.MapAccessor;
 import org.w3c.dom.Element;
@@ -80,13 +81,13 @@ public final class Index extends AbstractCatalogItem<Index.Type> {
 
 	private final Set<String> deconstructedIdentifiers;
 
-	Index(String name, Type type, TargetEntityType targetEntityType, Collection<String> deconstructedIdentifiers,
-			Collection<String> properties) {
+	Index(@Nullable String name, Type type, TargetEntityType targetEntityType,
+			Collection<String> deconstructedIdentifiers, Collection<String> properties) {
 		this(name, type, targetEntityType, deconstructedIdentifiers, properties, null);
 	}
 
-	Index(String name, Type type, TargetEntityType targetEntityType, Collection<String> deconstructedIdentifiers,
-			Collection<String> properties, String options) {
+	Index(@Nullable String name, Type type, TargetEntityType targetEntityType,
+			Collection<String> deconstructedIdentifiers, Collection<String> properties, @Nullable String options) {
 		super(name, type, targetEntityType, join(deconstructedIdentifiers), properties, options);
 		if (deconstructedIdentifiers.size() > 1 && type != Type.FULLTEXT) {
 			throw new IllegalArgumentException(
@@ -226,7 +227,7 @@ public final class Index extends AbstractCatalogItem<Index.Type> {
 	}
 
 	@Override
-	public Index withName(String newName) {
+	public Index withName(@Nullable String newName) {
 
 		if (Objects.equals(super.getName().getValue(), newName)) {
 			return this;
@@ -432,7 +433,7 @@ public final class Index extends AbstractCatalogItem<Index.Type> {
 
 		private final String[] identifiers;
 
-		private String name;
+		@Nullable private String name;
 
 		private DefaultBuilder(TargetEntityType targetEntity, String[] identifiers) {
 			this.targetEntity = targetEntity;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/IndexToCypherRenderer.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/IndexToCypherRenderer.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import ac.simons.neo4j.migrations.core.Neo4jVersion;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Renders indexes (supported operators are {@link Operator#CREATE} and
@@ -53,7 +54,10 @@ enum IndexToCypherRenderer implements Renderer<Index> {
 
 	private static final Pattern UNESCAPED_QUOTE = Pattern.compile("(?<!\\\\)'");
 
-	private static final UnaryOperator<String> TO_LITERAL = v -> {
+	private static final UnaryOperator<@Nullable String> TO_LITERAL = v -> {
+		if (v == null) {
+			return "NULL";
+		}
 		String result = UNESCAPED_QUOTE.matcher(v.replace(ESCAPED_UNICODE_QUOTE, "'")).replaceAll("\\\\'");
 		return "'" + result + "'";
 	};
@@ -154,8 +158,8 @@ enum IndexToCypherRenderer implements Renderer<Index> {
 		}
 	}
 
-	private String renderCreateFulltext(Index index, RenderConfig config, Neo4jVersion version, String indexName,
-			String identifier) {
+	private String renderCreateFulltext(Index index, RenderConfig config, Neo4jVersion version,
+			@Nullable String indexName, String identifier) {
 
 		String safeName;
 		if (RANGE_35_TO_42.contains(version)) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Name.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/Name.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import ac.simons.neo4j.migrations.core.internal.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The unique id of an {@link CatalogItem item}.
@@ -33,7 +34,7 @@ public sealed interface Name permits AbstractName {
 	 * @param value the value of the name
 	 * @return a name
 	 */
-	static Name of(String value) {
+	static Name of(@Nullable String value) {
 		return (value != null) ? new DefaultName(value) : DefaultName.EMPTY;
 	}
 
@@ -50,7 +51,7 @@ public sealed interface Name permits AbstractName {
 	 * @return a generated name
 	 */
 	static Name generate(Class<?> classType, ItemType itemType, TargetEntityType targetEntityType, String identifier,
-			Collection<String> properties, String options) {
+			Collection<String> properties, @Nullable String options) {
 
 		String src = String.format("{type=%s, targetEntity=%s, identifier='%s', properties='%s'%s}", itemType,
 				targetEntityType, identifier, String.join(",", properties),
@@ -65,6 +66,6 @@ public sealed interface Name permits AbstractName {
 	/**
 	 * {@return the {@link String string representation} of this instance}
 	 */
-	String getValue();
+	@Nullable String getValue();
 
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/RenderConfig.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/catalog/RenderConfig.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import ac.simons.neo4j.migrations.core.Neo4jEdition;
 import ac.simons.neo4j.migrations.core.Neo4jVersion;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contextual information passed to renderers.
@@ -41,7 +42,7 @@ public final class RenderConfig {
 	 */
 	private final Neo4jEdition edition;
 
-	private final Operator operator;
+	@Nullable private final Operator operator;
 
 	private final boolean idempotent;
 
@@ -63,12 +64,13 @@ public final class RenderConfig {
 	 */
 	private final boolean useExplicitPropertyIndexType;
 
-	RenderConfig(Neo4jVersion version, Neo4jEdition edition, Operator operator, boolean idempotent) {
+	RenderConfig(Neo4jVersion version, Neo4jEdition edition, @Nullable Operator operator, boolean idempotent) {
 		this(version, edition, operator, idempotent, false, null);
 	}
 
-	RenderConfig(Neo4jVersion version, Neo4jEdition edition, Operator operator, boolean idempotent, boolean ignoreName,
-			@SuppressWarnings("squid:S1874") List<AdditionalRenderingOptions> additionalOptions) {
+	RenderConfig(Neo4jVersion version, Neo4jEdition edition, @Nullable Operator operator, boolean idempotent,
+			boolean ignoreName,
+			@SuppressWarnings("squid:S1874") @Nullable List<AdditionalRenderingOptions> additionalOptions) {
 		this.version = version;
 		this.edition = edition;
 		this.operator = operator;
@@ -119,7 +121,7 @@ public final class RenderConfig {
 		return this.edition;
 	}
 
-	Operator getOperator() {
+	@Nullable Operator getOperator() {
 		return this.operator;
 	}
 
@@ -303,7 +305,7 @@ public final class RenderConfig {
 		 * {@code UNDEFINED}
 		 * @return a config accommodating the given version and edition
 		 */
-		default RenderConfig forVersionAndEdition(String version, String edition) {
+		default RenderConfig forVersionAndEdition(@Nullable String version, String edition) {
 			return forVersionAndEdition(Neo4jVersion.of(version), Neo4jEdition.of(edition));
 		}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/UncheckedNoSuchAlgorithmException.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/UncheckedNoSuchAlgorithmException.java
@@ -15,6 +15,8 @@
  */
 package ac.simons.neo4j.migrations.core.internal;
 
+import java.io.Serial;
+
 /**
  * Unchecked analogue to {@link java.io.UncheckedIOException}.
  *
@@ -23,6 +25,7 @@ package ac.simons.neo4j.migrations.core.internal;
  */
 public final class UncheckedNoSuchAlgorithmException extends RuntimeException {
 
+	@Serial
 	private static final long serialVersionUID = 6879942930900663370L;
 
 	UncheckedNoSuchAlgorithmException(Throwable cause) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/package-info.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/internal/package-info.java
@@ -3,4 +3,7 @@
  * accessible when this project is used on the Java Module Path and are not subject to
  * semantic versioning.
  */
+@NullUnmarked
 package ac.simons.neo4j.migrations.core.internal;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/AbstractCustomizableRefactoring.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/AbstractCustomizableRefactoring.java
@@ -19,6 +19,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Abstract base class to hold state that many refactorings have, such as custom queries
  * or a batch-size.
@@ -33,27 +35,27 @@ abstract class AbstractCustomizableRefactoring {
 	 * labels or types should be renamed. This query must return rows with one single
 	 * element per row. This is checked upon before executing.
 	 */
-	protected final String customQuery;
+	@Nullable protected final String customQuery;
 
 	/**
 	 * The batch size to perform renaming. If {@literal null}, no batching is attempted
 	 * and the refactoring will use one a transactional function when applied. Setting
 	 * this to a value different from {@literal null} also requires Neo4j >= 4.4
 	 */
-	protected final Integer batchSize;
+	@Nullable protected final Integer batchSize;
 
-	protected AbstractCustomizableRefactoring(String customQuery, Integer batchSize) {
+	protected AbstractCustomizableRefactoring(@Nullable String customQuery, @Nullable Integer batchSize) {
 		this.customQuery = customQuery;
 		this.batchSize = batchSize;
 	}
 
-	protected final String filterCustomQuery(String newCustomQuery) {
+	@Nullable protected final String filterCustomQuery(@Nullable String newCustomQuery) {
 		return Optional.ofNullable(newCustomQuery).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
 	}
 
-	protected final <T extends CustomizableRefactoring<?>> T inBatchesOf0(Integer newBatchSize, Class<T> type,
+	protected final <T extends CustomizableRefactoring<?>> T inBatchesOf0(@Nullable Integer newBatchSize, Class<T> type,
 			@SuppressWarnings("squid:S4276") // The new batchsize might as well be null
-			Function<Integer, ? extends T> newInstanceSupplier) {
+			Function<@Nullable Integer, ? extends T> newInstanceSupplier) {
 		if (newBatchSize != null && newBatchSize < 1) {
 			throw new IllegalArgumentException("Batch size must be either null or equal or greater one");
 		}
@@ -61,8 +63,8 @@ abstract class AbstractCustomizableRefactoring {
 		return Objects.equals(this.batchSize, newBatchSize) ? type.cast(this) : newInstanceSupplier.apply(newBatchSize);
 	}
 
-	protected final <T extends CustomizableRefactoring<?>> T withCustomQuery0(String newCustomQuery, Class<T> type,
-			Function<String, ? extends T> newInstanceSupplier) {
+	protected final <T extends CustomizableRefactoring<?>> T withCustomQuery0(@Nullable String newCustomQuery,
+			Class<T> type, Function<@Nullable String, ? extends T> newInstanceSupplier) {
 		String value = filterCustomQuery(newCustomQuery);
 
 		return Objects.equals(this.customQuery, value) ? type.cast(this) : newInstanceSupplier.apply(newCustomQuery);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultAddSurrogateKey.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultAddSurrogateKey.java
@@ -26,6 +26,7 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 
 /**
@@ -56,8 +57,8 @@ final class DefaultAddSurrogateKey extends AbstractCustomizableRefactoring imple
 		this(target, null, property, generator, customQuery, null);
 	}
 
-	private DefaultAddSurrogateKey(Target target, Collection<String> identifiers, String property, String generator,
-			String customQuery, Integer batchSize) {
+	private DefaultAddSurrogateKey(Target target, @Nullable Collection<String> identifiers, String property,
+			String generator, @Nullable String customQuery, @Nullable Integer batchSize) {
 		super(customQuery, batchSize);
 
 		this.target = target;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultListToVector.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultListToVector.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 
 final class DefaultListToVector extends AbstractCustomizableRefactoring implements ListToVector {
@@ -39,8 +40,8 @@ final class DefaultListToVector extends AbstractCustomizableRefactoring implemen
 
 	private final QueryRunner.FeatureSet featureSet;
 
-	DefaultListToVector(Target target, Collection<String> identifiers, String property, String customQuery,
-			Integer batchSize, ElementType elementType) {
+	DefaultListToVector(Target target, @Nullable Collection<String> identifiers, @Nullable String property,
+			@Nullable String customQuery, @Nullable Integer batchSize, @Nullable ElementType elementType) {
 		super(customQuery, batchSize);
 		this.target = Objects.requireNonNull(target);
 		this.identifiers = (identifiers != null)

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMerge.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMerge.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Value;
@@ -98,12 +99,13 @@ final class DefaultMerge implements Merge {
 			return Optional.empty();
 		}
 		// using insertion order for maps so that query generation is deterministic
-		Map<String, Object> combinedProperties = new LinkedHashMap<>(rows.size());
+		Map<String, @Nullable Object> combinedProperties = new LinkedHashMap<>(rows.size());
 		for (Map<String, ?> row : rows) {
 			for (Map.Entry<String, ?> entry : row.entrySet()) {
 				@SuppressWarnings("unchecked")
 				Map<String, Object> property = (Map<String, Object>) entry.getValue();
-				String propertyName = (String) property.get("key");
+				String propertyName = Objects.requireNonNull((String) property.get("key"),
+						"Property to merge on must be defined");
 				@SuppressWarnings("unchecked")
 				List<Object> aggregatedPropertyValues = (List<Object>) property.get("values");
 				Object value = findPolicy(policies, propertyName)
@@ -176,7 +178,7 @@ final class DefaultMerge implements Merge {
 	}
 
 	private static Optional<Query> generateNodeDeletion(Ids ids) {
-		return Optional.of(new Query(("MATCH (n) WHERE elementId(n) IN $ids DETACH DELETE n"),
+		return Optional.of(new Query("MATCH (n) WHERE elementId(n) IN $ids DETACH DELETE n",
 				Collections.singletonMap("ids", ids.tail)));
 	}
 
@@ -231,7 +233,7 @@ final class DefaultMerge implements Merge {
 		return Objects.hash(this.query, this.mergePolicies);
 	}
 
-	private record Ids(List<String> value, String first, List<String> tail) {
+	private record Ids(List<String> value, @Nullable String first, List<String> tail) {
 
 		static Ids of(List<String> ids) {
 			if (ids.isEmpty()) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultMigrateBTreeIndexes.java
@@ -36,6 +36,7 @@ import ac.simons.neo4j.migrations.core.catalog.Constraint;
 import ac.simons.neo4j.migrations.core.catalog.Index;
 import ac.simons.neo4j.migrations.core.catalog.RenderConfig;
 import ac.simons.neo4j.migrations.core.catalog.Renderer;
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Value;
@@ -93,8 +94,9 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 		this(false, null, null, null, null);
 	}
 
-	DefaultMigrateBTreeIndexes(boolean dropOldIndexes, String suffix, Map<String, Index.Type> typeMapping,
-			Collection<String> excludes, Collection<String> includes) {
+	DefaultMigrateBTreeIndexes(boolean dropOldIndexes, @Nullable String suffix,
+			@Nullable Map<String, Index.Type> typeMapping, @Nullable Collection<String> excludes,
+			@Nullable Collection<String> includes) {
 
 		this.dropOldIndexes = dropOldIndexes;
 		this.suffix = ((suffix != null) && !suffix.trim().isEmpty()) ? suffix.trim() : DEFAULT_SUFFIX;
@@ -275,7 +277,7 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 	}
 
 	@Override
-	public MigrateBTreeIndexes withExcludes(Collection<String> newExcludes) {
+	public MigrateBTreeIndexes withExcludes(@Nullable Collection<String> newExcludes) {
 		if (Objects.equals(this.excludes, newExcludes)
 				|| ((newExcludes == null || newExcludes.isEmpty()) && this.excludes.isEmpty())) {
 			return this;
@@ -286,7 +288,7 @@ final class DefaultMigrateBTreeIndexes implements MigrateBTreeIndexes {
 	}
 
 	@Override
-	public MigrateBTreeIndexes withIncludes(Collection<String> newIncludes) {
+	public MigrateBTreeIndexes withIncludes(@Nullable Collection<String> newIncludes) {
 		if (Objects.equals(this.includes, newIncludes)
 				|| ((newIncludes == null || newIncludes.isEmpty()) && this.includes.isEmpty())) {
 			return this;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultNormalize.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultNormalize.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Values;
 
@@ -46,8 +47,8 @@ final class DefaultNormalize extends AbstractCustomizableRefactoring implements 
 		this(property, trueValues, falseValues, null, null);
 	}
 
-	private DefaultNormalize(String property, List<Object> trueValues, List<Object> falseValues, String customQuery,
-			Integer batchSize) {
+	private DefaultNormalize(String property, List<Object> trueValues, List<Object> falseValues,
+			@Nullable String customQuery, @Nullable Integer batchSize) {
 		super(customQuery, batchSize);
 
 		boolean nullIsTrue = trueValues.stream().anyMatch(DefaultNormalize::isNull);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultRename.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/DefaultRename.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.jspecify.annotations.Nullable;
 import org.neo4j.driver.Query;
 
 /**
@@ -51,7 +52,8 @@ final class DefaultRename extends AbstractCustomizableRefactoring implements Ren
 		this(targetEntityType, oldValue, newValue, null, null);
 	}
 
-	private DefaultRename(Target target, String oldValue, String newValue, String customQuery, Integer batchSize) {
+	private DefaultRename(Target target, String oldValue, String newValue, @Nullable String customQuery,
+			@Nullable Integer batchSize) {
 		super(customQuery, batchSize);
 
 		this.target = target;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/FormatStringGenerator.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/FormatStringGenerator.java
@@ -15,6 +15,8 @@
  */
 package ac.simons.neo4j.migrations.core.refactorings;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Generates format strings for refactorings, depending on targets and / or custom
  * queries.
@@ -28,7 +30,7 @@ interface FormatStringGenerator {
 	 */
 	Fragments getFragments();
 
-	default String generateFormatString(String customQuery, Integer batchSize) {
+	default String generateFormatString(@Nullable String customQuery, @Nullable Integer batchSize) {
 		Fragments fragments = getFragments();
 
 		String ptSource;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/Merge.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/Merge.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Refactoring that allows merging of entities.
  *
@@ -98,8 +100,8 @@ public sealed interface Merge extends Refactoring permits DefaultMerge {
 			return this.pattern;
 		}
 
-		Object apply(List<Object> values) {
-			if (values.isEmpty()) {
+		@Nullable Object apply(@Nullable List<Object> values) {
+			if (values == null || values.isEmpty()) {
 				return null;
 			}
 			return switch (this.strategy) {
@@ -111,13 +113,9 @@ public sealed interface Merge extends Refactoring permits DefaultMerge {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
+			if (!(o instanceof PropertyMergePolicy that)) {
 				return false;
 			}
-			PropertyMergePolicy that = (PropertyMergePolicy) o;
 			return this.pattern.pattern().equals(that.pattern.pattern()) && this.strategy == that.strategy;
 		}
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/MigrateBTreeIndexes.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/MigrateBTreeIndexes.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import ac.simons.neo4j.migrations.core.catalog.Index;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Migrates existing B-tree indexes and constraints backed by such indexes to Neo4j 5.0+
@@ -61,7 +62,7 @@ public sealed interface MigrateBTreeIndexes extends Refactoring permits DefaultM
 	 * @param suffix the suffix to use
 	 * @return the refactoring ready to use
 	 */
-	static MigrateBTreeIndexes createFutureIndexes(String suffix) {
+	static MigrateBTreeIndexes createFutureIndexes(@Nullable String suffix) {
 		return new DefaultMigrateBTreeIndexes(false, suffix, Collections.emptyMap(), Collections.emptyList(),
 				Collections.emptyList());
 	}
@@ -91,7 +92,7 @@ public sealed interface MigrateBTreeIndexes extends Refactoring permits DefaultM
 	 * @param excludes indexes and constraints to ignore
 	 * @return the refactoring ready to use
 	 */
-	MigrateBTreeIndexes withExcludes(Collection<String> excludes);
+	MigrateBTreeIndexes withExcludes(@Nullable Collection<String> excludes);
 
 	/**
 	 * Configures an include list. An empty or {@literal null} value disables the
@@ -100,6 +101,6 @@ public sealed interface MigrateBTreeIndexes extends Refactoring permits DefaultM
 	 * @param newIncludes new includes
 	 * @return the refactoring ready to use
 	 */
-	MigrateBTreeIndexes withIncludes(Collection<String> newIncludes);
+	MigrateBTreeIndexes withIncludes(@Nullable Collection<String> newIncludes);
 
 }

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/QueryRunner.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/QueryRunner.java
@@ -21,8 +21,8 @@ import org.neo4j.driver.Query;
 import org.neo4j.driver.Result;
 
 /**
- * A simplification over a standard {@see org.neo4j.driver.QueryRunner}. This query runner
- * here is also autocloseable and can and should be treated as such.
+ * A simplification over a standard see {@link org.neo4j.driver.QueryRunner}. This query
+ * runner here is also autocloseable and can and should be treated as such.
  *
  * @author Michael J. Simons
  * @since 1.10.0

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/RefactoringContext.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/refactorings/RefactoringContext.java
@@ -19,10 +19,12 @@ import java.util.Optional;
 
 import ac.simons.neo4j.migrations.core.Neo4jVersion;
 import ac.simons.neo4j.migrations.core.refactorings.QueryRunner.FeatureSet;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A wrapper around access to a Neo4j database. It requires an implementation of a
- * simplified {@see org.neo4j.driver.QueryRunner} based on official Neo4j driver types.
+ * simplified see {@link org.neo4j.driver.QueryRunner} based on official Neo4j driver
+ * types.
  *
  * @author Michael J. Simons
  * @since 1.10.0
@@ -59,7 +61,7 @@ public interface RefactoringContext {
 	 * @return the sanitized and quoted value or the same value if no change is necessary.
 	 * @since 1.11.0
 	 */
-	default String sanitizeSchemaName(String potentiallyNonIdentifier) {
+	@Nullable default String sanitizeSchemaName(String potentiallyNonIdentifier) {
 
 		return Neo4jVersion.LATEST.sanitizeSchemaName(potentiallyNonIdentifier);
 	}

--- a/neo4j-migrations-core/src/main/java/module-info.java
+++ b/neo4j-migrations-core/src/main/java/module-info.java
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Neo4j-Migrations core module.
  * @author Michael J. Simons
  * @since 2.0.0
  */
 @SuppressWarnings("requires-automatic")
+@NullMarked
 module ac.simons.neo4j.migrations.core {
 
 	requires io.github.classgraph;
@@ -29,6 +33,9 @@ module ac.simons.neo4j.migrations.core {
 	requires transitive java.xml;
 
 	requires transitive org.neo4j.driver;
+	requires transitive org.jspecify;
+	requires io.netty.common;
+	requires java.sql;
 
 	exports ac.simons.neo4j.migrations.core;
 	exports ac.simons.neo4j.migrations.core.catalog;

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/PackageStructureTests.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/PackageStructureTests.java
@@ -75,15 +75,13 @@ class PackageStructureTests {
 			.resideInAPackage("..internal..")
 			.should()
 			.dependOnClassesThat(resideOutsideOfPackages("..internal", "java..", "javax..", "org.xml..", "org.w3c..",
-					"org.neo4j.cypherdsl.support.schema_name.." // That will be shaded
-																// anyway into the same
-																// internal package
-			).and(areNotPrimitives()));
+					"org.neo4j.cypherdsl.support.schema_name..", "org.jspecify.annotations..")
+				.and(areNotPrimitives()));
 		rule.check(this.coreClasses);
 	}
 
 	DescribedPredicate<JavaClass> areNotPrimitives() {
-		return not(new DescribedPredicate<JavaClass>("Should be a primitive") {
+		return not(new DescribedPredicate<>("Should be a primitive") {
 			@Override
 			public boolean test(JavaClass input) {
 				return input.isPrimitive() || (input.isArray() && input.getBaseComponentType().isPrimitive());

--- a/neo4j-migrations-examples/neo4j-migrations-cluster-tests/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-cluster-tests/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cluster-tests</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb-testharness</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb</artifactId>

--- a/neo4j-migrations-examples/pom.xml
+++ b/neo4j-migrations-examples/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples</artifactId>

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-maven-plugin</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/pom.xml
+++ b/neo4j-migrations-quarkus-parent/deployment/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-deployment</artifactId>
@@ -142,7 +142,7 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration combine.self="append">
-					<annotationProcessorPaths>
+					<annotationProcessorPaths combine.children="append">
 						<path>
 							<groupId>io.quarkus</groupId>
 							<artifactId>quarkus-extension-processor</artifactId>

--- a/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
+++ b/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-integration-tests</artifactId>

--- a/neo4j-migrations-quarkus-parent/pom.xml
+++ b/neo4j-migrations-quarkus-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-parent</artifactId>

--- a/neo4j-migrations-quarkus-parent/runtime/pom.xml
+++ b/neo4j-migrations-quarkus-parent/runtime/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus</artifactId>
@@ -106,7 +106,7 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration combine.self="append">
-					<annotationProcessorPaths>
+					<annotationProcessorPaths combine.children="append">
 						<path>
 							<groupId>io.quarkus</groupId>
 							<artifactId>quarkus-extension-processor</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-autoconfigure</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>

--- a/neo4j-migrations-test-resources/pom.xml
+++ b/neo4j-migrations-test-resources/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-resources</artifactId>

--- a/neo4j-migrations-test-results/pom.xml
+++ b/neo4j-migrations-test-results/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-results</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>eu.michael-simons.neo4j</groupId>
 	<artifactId>neo4j-migrations-parent</artifactId>
-	<version>3.3.2-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Neo4j Migrations</name>
@@ -115,6 +115,7 @@
 		<docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
 		<docsImagesDir>${basedir}/docs/modules/ROOT/images</docsImagesDir>
 		<error_prone_annotations.version>2.49.0</error_prone_annotations.version>
+		<errorprone.version>2.49.0</errorprone.version>
 		<exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
 		<flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
 		<guava.version>33.5.0-jre</guava.version>
@@ -161,6 +162,7 @@
 		<neo4j-ogm.version>5.0.5</neo4j-ogm.version>
 		<neo4j.image>neo4j:${neo4j.version}</neo4j.image>
 		<neo4j.version>2026.03.1</neo4j.version>
+		<nullaway.version>0.13.2</nullaway.version>
 		<objenesis.version>3.5</objenesis.version>
 		<os-maven-plugin.version>1.7.1</os-maven-plugin.version>
 		<picocli.version>4.7.7</picocli.version>
@@ -435,7 +437,7 @@
 							<configuration>
 								<forceLegacyJavacApi>true</forceLegacyJavacApi>
 								<showWarnings>true</showWarnings>
-								<compilerArgs>
+								<compilerArgs combine.self="override">
 									<arg>-Xlint:all,-options,-path,-processing,-classfile,-exports,-missing-explicit-ctor</arg>
 									<arg>-Werror</arg>
 									<arg>-parameters</arg>
@@ -754,6 +756,11 @@
 							<type>LICENSE_NAME</type>
 							<rule>APPROVE</rule>
 							<value>The Apache Software License, version 2.0</value>
+						</dependencyPolicy>
+						<dependencyPolicy>
+							<type>LICENSE_NAME</type>
+							<rule>APPROVE</rule>
+							<value>The Apache License, Version 2.0</value>
 						</dependencyPolicy>
 						<dependencyPolicy>
 							<type>LICENSE_NAME</type>
@@ -1208,6 +1215,41 @@
 			<properties>
 				<asciidoctor.skip>true</asciidoctor.skip>
 			</properties>
+		</profile>
+		<profile>
+			<id>nullAway</id>
+			<activation>
+				<property>
+					<name>!disableNullAway</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<compilerArgs combine.self="append">
+								<arg>-XDcompilePolicy=simple</arg>
+								<arg>--should-stop=ifError=FLOW</arg>
+								<arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true</arg>
+							</compilerArgs>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>com.google.errorprone</groupId>
+									<artifactId>error_prone_core</artifactId>
+									<version>${errorprone.version}</version>
+								</path>
+								<path>
+									<groupId>com.uber.nullaway</groupId>
+									<artifactId>nullaway</artifactId>
+									<version>${nullaway.version}</version>
+								</path>
+							</annotationProcessorPaths>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<?SORTPOM IGNORE?>
 		<profile>


### PR DESCRIPTION
The whole of the core modules is now `@NullMarked` and all flows are checked via ErrorProne/NullAway during compilation, making the core module fully `null` safe.

This changes poses for Kotlin users a potentially breaking API change due to parameters becoming not-nullable respectively nullable types in some areas.

Signed-off-by: Michael Simons <michael@simons.ac>
