### PR TITLE
fix: Validate uniqueness of versions during discovery and within applied migrations.

### DIFF
--- a/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/catalog/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-catalog</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor-api/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor-api</artifactId>

--- a/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
+++ b/extensions/neo4j-migrations-annotation-processing/processor/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-annotation-processing</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-annotation-processor</artifactId>

--- a/extensions/neo4j-migrations-formats-adoc/pom.xml
+++ b/extensions/neo4j-migrations-formats-adoc/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-csv/pom.xml
+++ b/extensions/neo4j-migrations-formats-csv/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/extensions/neo4j-migrations-formats-markdown/pom.xml
+++ b/extensions/neo4j-migrations-formats-markdown/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/neo4j-migrations-bom/pom.xml
+++ b/neo4j-migrations-bom/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-bom</artifactId>

--- a/neo4j-migrations-cli/pom.xml
+++ b/neo4j-migrations-cli/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cli</artifactId>

--- a/neo4j-migrations-core/pom.xml
+++ b/neo4j-migrations-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations</artifactId>

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainBuilder.java
@@ -218,9 +218,15 @@ final class ChainBuilder {
 								|| end.get("type").asString().equals("DELETE")) {
 							return;
 						}
-						Element chainElement = DefaultMigrationChainElement.appliedElement(segment, repetitions);
-						chain.put(MigrationVersion.withValue(chainElement.getVersion(),
-								end.get("repeatable").asBoolean(false)), chainElement);
+						var chainElement = DefaultMigrationChainElement.appliedElement(segment, repetitions);
+						var version = MigrationVersion.withValue(chainElement.getVersion(),
+								end.get("repeatable").asBoolean(false));
+						var existing = chain.get(version);
+						if (existing != null && this.alwaysVerify) {
+							throw new DuplicateMigrationsException(version,
+									List.of(existing.getSource(), chainElement.getSource()));
+						}
+						chain.put(version, chainElement);
 					});
 				}
 				return chain;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
@@ -123,7 +123,7 @@ final class ChainTool {
 						""",
 						Values.parameters("migrationTarget", migrationTarget))
 				.stream()
-				.map(record -> MigrationVersion.withValue(record.get("version").asString()))
+				.map(row -> MigrationVersion.withValue(row.get("version").asString()))
 				.sorted(config.getVersionComparator())
 				.toList();
 			result.addAll(deleteDuplicateVersions(Neo4jVersion.of(context.getConnectionDetails().getServerVersion()),

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ChainTool.java
@@ -108,10 +108,61 @@ final class ChainTool {
 
 		var migrationTarget = config.getMigrationTargetIn(context).orElse(null);
 
-		List<Query> result = new ArrayList<>(fixChecksums(migrationTarget));
+		List<Query> result = new ArrayList<>();
+		// we could determine them in the query itself, but we cannot easily generate the
+		// same order of versions
+		// inside the database that we provide via lexicographic or semantic ordering
+		try (var session = context.getSchemaSession()) {
+			var duplicateVersions = session
+				.run("""
+						MATCH (n:__Neo4jMigration WHERE coalesce(n.migrationTarget, '<default>') = coalesce($migrationTarget,'<default>'))
+						WITH n.version AS version, n.migrationTarget AS migrationTarget, count(*) AS cnt
+						ORDER BY n.version
+						WHERE cnt > 1
+						RETURN version AS version
+						""",
+						Values.parameters("migrationTarget", migrationTarget))
+				.stream()
+				.map(record -> MigrationVersion.withValue(record.get("version").asString()))
+				.sorted(config.getVersionComparator())
+				.toList();
+			result.addAll(deleteDuplicateVersions(Neo4jVersion.of(context.getConnectionDetails().getServerVersion()),
+					migrationTarget, duplicateVersions));
+		}
+
+		result.addAll(fixChecksums(migrationTarget));
 		result.addAll(deleteLocallyMissingMigrations(migrationTarget));
 		result.addAll(insertRemoteMissingMigrations(migrationTarget, config.getOptionalInstalledBy()));
 		return result;
+	}
+
+	private List<Query> deleteDuplicateVersions(Neo4jVersion neo4jVersion, @Nullable String migrationTarget,
+			List<MigrationVersion> duplicateVersions) {
+
+		var cypher = """
+				MATCH (n:__Neo4jMigration WHERE n.version = $version AND coalesce(n.migrationTarget, '<default>') = coalesce($migrationTarget,'<default>'))
+				OPTIONAL MATCH (predecessor:__Neo4jMigration)-[inRel:MIGRATED_TO]->(n)
+				WITH n,
+				     inRel.at AS inAt,
+				     CASE WHEN predecessor IS NOT NULL AND predecessor.version <> $version
+				          THEN 0 ELSE 1 END AS canonicalRank
+				ORDER BY canonicalRank ASC, inAt ASC, %s(n) ASC
+				WITH collect(DISTINCT n) AS nodes
+				WITH nodes[0] AS keeper, nodes[1..] AS dups
+				OPTIONAL MATCH (lastDup)-[afterRel:MIGRATED_TO]->(after:__Neo4jMigration)
+				WHERE lastDup IN dups AND after <> keeper AND NOT after IN dups
+				WITH keeper, dups, after, properties(afterRel) AS afterProps
+				FOREACH (_ IN CASE WHEN after IS NOT NULL THEN [1] ELSE [] END |
+				  MERGE (keeper)-[bridge:MIGRATED_TO]->(after) ON CREATE SET bridge = afterProps
+				)
+				WITH dups
+				UNWIND dups AS dup DETACH DELETE dup"""
+			.formatted(neo4jVersion.is5OrHigher() ? "elementId" : "id");
+
+		return duplicateVersions.stream()
+			.map(version -> new Query(cypher,
+					Values.parameters("version", version.getValue(), "migrationTarget", migrationTarget)))
+			.toList();
 	}
 
 	private List<Query> fixChecksums(@Nullable String migrationTarget) {

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DiscoveryService.java
@@ -89,8 +89,7 @@ final class DiscoveryService {
 			List<Migration> v = entry.getValue();
 			if (v.size() > 1) {
 				MigrationVersion k = entry.getKey();
-				String sources = v.stream().map(Migration::getSource).sorted().collect(Collectors.joining(", "));
-				throw new MigrationsException("Duplicate version '" + k.getValue() + "' (" + sources + ")");
+				throw new DuplicateMigrationsException(k, v.stream().map(Migration::getSource).sorted().toList());
 			}
 		}
 		return List.copyOf(migrations);

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DuplicateMigrationsException.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/DuplicateMigrationsException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ac.simons.neo4j.migrations.core;
+
+import java.io.Serial;
+import java.util.List;
+
+/**
+ * Indicator to be thrown by the discovery service (among others), so that we can properly
+ * validate local chains already without checking the message of the exception.
+ *
+ * @author Michael J. Simons
+ * @since 4.1.0
+ */
+final class DuplicateMigrationsException extends MigrationsException {
+
+	@Serial
+	private static final long serialVersionUID = 8035093680190055621L;
+
+	DuplicateMigrationsException(MigrationVersion version, List<String> sources) {
+		super("Duplicate version '%s' (%s)".formatted(version.getValue(), String.join(", ", sources)));
+	}
+
+}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -146,7 +146,6 @@ public final class Migrations {
 
 		// Composite unique constraints are not supported here
 		if (!HBD.is44OrHigher(context.getConnectionDetails())) {
-			System.out.println("out");
 			return;
 		}
 
@@ -157,7 +156,6 @@ public final class Migrations {
 				.forVersionAndEdition(cd.getServerVersion(), cd.getServerEdition());
 
 			var stmt = Renderer.get(Renderer.Format.CYPHER, Constraint.class).render(UNIQUE_VERSION, createConfig);
-			System.out.println(stmt);
 			HBD.silentCreateConstraintOrIndex(context.getConnectionDetails(), session, stmt, null,
 					() -> "Could not create unique constraint for targeted migrations.");
 

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/Migrations.java
@@ -146,6 +146,7 @@ public final class Migrations {
 
 		// Composite unique constraints are not supported here
 		if (!HBD.is44OrHigher(context.getConnectionDetails())) {
+			System.out.println("out");
 			return;
 		}
 
@@ -156,6 +157,7 @@ public final class Migrations {
 				.forVersionAndEdition(cd.getServerVersion(), cd.getServerEdition());
 
 			var stmt = Renderer.get(Renderer.Format.CYPHER, Constraint.class).render(UNIQUE_VERSION, createConfig);
+			System.out.println(stmt);
 			HBD.silentCreateConstraintOrIndex(context.getConnectionDetails(), session, stmt, null,
 					() -> "Could not create unique constraint for targeted migrations.");
 
@@ -671,9 +673,9 @@ public final class Migrations {
 
 	private ValidationResult validate0() {
 
-		List<Migration> migrations = this.getMigrations();
 		Optional<String> targetDatabase = this.config.getOptionalSchemaDatabase();
 		try {
+			List<Migration> migrations = this.getMigrations();
 			MigrationChain migrationChain = new ChainBuilder(true).buildChain(this.context, migrations, true,
 					ChainBuilderMode.COMPARE);
 			int numberOfAppliedMigrations = (int) migrationChain.getElements()
@@ -689,8 +691,11 @@ public final class Migrations {
 			}
 			return new ValidationResult(targetDatabase, Outcome.UNDEFINED, Collections.emptyList());
 		}
+		catch (DuplicateMigrationsException ex) {
+			return new ValidationResult(targetDatabase, Outcome.DUPLICATE_VERSION, List.of(ex.getMessage()));
+		}
 		catch (MigrationsException ex) {
-			List<String> warnings = Collections.singletonList(ex.getMessage());
+			List<String> warnings = List.of(ex.getMessage());
 			if (ex.getCause() instanceof IndexOutOfBoundsException) {
 				return new ValidationResult(targetDatabase, Outcome.INCOMPLETE_MIGRATIONS, warnings);
 			}

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsException.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/MigrationsException.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
  * @author Michael J. Simons
  * @since 0.0.1
  */
-public final class MigrationsException extends RuntimeException {
+public sealed class MigrationsException extends RuntimeException permits DuplicateMigrationsException {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ValidationResult.java
+++ b/neo4j-migrations-core/src/main/java/ac/simons/neo4j/migrations/core/ValidationResult.java
@@ -128,7 +128,15 @@ public final class ValidationResult implements DatabaseOperationResult {
 		 * Some migrations have been changed since they have been applied to the target
 		 * database or their version doesn't fit anymore. The database must be repaired.
 		 */
-		DIFFERENT_CONTENT
+		DIFFERENT_CONTENT,
+
+		/**
+		 * A version number is used more than once. This can only happen when schema
+		 * database and migration database are the same (no property migrationTarget
+		 * recorded, unique_version___Neo4jMigration won't apply).
+		 * @since 4.1.0
+		 */
+		DUPLICATE_VERSION
 
 	}
 

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ChainToolTests.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ChainToolTests.java
@@ -41,12 +41,19 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
+import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -107,6 +114,25 @@ final class ChainToolTests {
 		given(pathSegment.end()).willReturn(targetMigration);
 		given(pathSegment.relationship()).willReturn(relationship);
 		return DefaultMigrationChainElement.appliedElement(pathSegment, List.of());
+	}
+
+	MigrationContext mockContext(MigrationsConfig config) {
+
+		var driver = mock(Driver.class);
+		var result = mock(Result.class);
+		given(result.consume()).willReturn(mock(ResultSummary.class));
+		var session = mock(Session.class);
+		given(session.run(anyString(), any(Value.class))).willReturn(result);
+		given(session.run(anyString())).willReturn(result);
+		given(driver.session(any(SessionConfig.class))).willReturn(session);
+
+		var context = mock(MigrationContext.class);
+		given(context.getDriver()).willReturn(driver);
+		given(context.getConfig()).willReturn(config);
+		given(context.getConnectionDetails())
+			.willReturn(ConnectionDetails.of("n/a", "2026.05.0", "Enterprise", "msimons", null, null));
+		given(context.getSchemaSession()).willReturn(session);
+		return context;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -248,7 +274,7 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
+			var queries = chainTool.repair(config, mockContext(config));
 			assertThat(queries).hasSize(2).satisfies(q -> {
 				assertThat(q.parameters().get("version").asString()).isEqualTo("01");
 				assertThat(q.parameters().get("newChecksum").asString()).isEqualTo("E_1vNew");
@@ -272,10 +298,10 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
-			assertThat(queries).hasSize(1).first().satisfies(q -> {
-				assertThat(q.parameters().get("version").asString()).isEqualTo("03");
-			});
+			var queries = chainTool.repair(config, mockContext(config));
+			assertThat(queries).hasSize(1)
+				.first()
+				.satisfies(q -> assertThat(q.parameters().get("version").asString()).isEqualTo("03"));
 		}
 
 	}
@@ -295,7 +321,7 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
+			var queries = chainTool.repair(config, mockContext(config));
 
 			assertThat(queries).hasSize(2)
 				.satisfies(q -> assertThat(q.parameters().get("version").asString()).isEqualTo("01"), Index.atIndex(0))
@@ -317,7 +343,7 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
+			var queries = chainTool.repair(config, mockContext(config));
 
 			assertThat(queries).hasSize(2)
 				.satisfies(q -> assertThat(q.parameters().get("version").asString()).isEqualTo("02"), Index.atIndex(0))
@@ -339,7 +365,7 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
+			var queries = chainTool.repair(config, mockContext(config));
 
 			assertThat(queries).isEmpty();
 		}
@@ -358,7 +384,7 @@ final class ChainToolTests {
 			var chainTool = new ChainTool(MigrationsConfig.defaultConfig().getVersionComparator(), List.of(), source,
 					target);
 			var config = MigrationsConfig.defaultConfig();
-			var queries = chainTool.repair(config, new DefaultMigrationContext(config, mock(Driver.class)));
+			var queries = chainTool.repair(config, mockContext(config));
 
 			assertThat(queries).hasSize(1)
 				.first()

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/MigrationsIT.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +62,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.types.Node;
 import org.testcontainers.neo4j.Neo4jContainer;
@@ -1352,6 +1354,50 @@ class MigrationsIT extends TestBase {
 
 	@Nested
 	class Repairing {
+
+		@Test
+		void shouldFixDuplicates() {
+
+			// Note: Those migrations must not have a property `migrationTarget`,
+			// otherwise unique_version___Neo4jMigration
+			// will catch those and prevent the invalid database state.
+			try (var session = MigrationsIT.this.driver.session()) {
+				session
+					.run("""
+							CREATE (:`__Neo4jMigration` {version:"BASELINE"})
+							-[:MIGRATED_TO {connectedAs:"neo4j",at:$when,in:$duration,by:"msimons"}]->
+							     (:`__Neo4jMigration` {checksum:"1100083332",description:"delete old data",source:"V0001__delete_old_data.cypher",type:"CYPHER",version:"0001"})
+							-[:MIGRATED_TO {connectedAs:"deleted1",at:$when,in:$duration,by:"msimons"}]->
+							     (:`__Neo4jMigration` {checksum:"1100083332",description:"delete old data",source:"V0001__delete_old_data_a.cypher",type:"CYPHER",version:"0001"})
+							-[:MIGRATED_TO {connectedAs:"deleted2",at:$when,in:$duration,by:"msimons"}]->
+							     (:`__Neo4jMigration` {checksum:"1100083332",description:"delete old data",source:"V0001__delete_old_data_b.cypher",type:"CYPHER",version:"0001"})
+							-[:MIGRATED_TO {connectedAs:"neo4j",at:$when,in:$duration,by:"msimons"}]->
+							     (:`__Neo4jMigration` {checksum:"3226785110",description:"create new data",source:"V0002__create_new_data.cypher",type:"CYPHER",version:"0002"})
+							 -[:MIGRATED_TO {connectedAs:"deleted2",at:$when,in:$duration,by:"msimons"}]->
+							     (:`__Neo4jMigration` {checksum:"3226785110",description:"create new data",source:"V0002__create_new_data_a.cypher",type:"CYPHER",version:"0002"})
+							""",
+							Values.parameters("when", ZonedDateTime.now(), "duration", Duration.ofSeconds(23)))
+					.consume();
+			}
+
+			var migrations = new Migrations(MigrationsConfig.builder().withLocationsToScan("/some/changeset").build(),
+					MigrationsIT.this.driver);
+			var result = migrations.repair();
+			assertThat(result.getOutcome()).isEqualTo(RepairmentResult.Outcome.REPAIRED);
+			assertThat(result.getNodesDeleted()).isEqualTo(3);
+			assertThat(result.getRelationshipsDeleted()).isEqualTo(4);
+			assertThat(result.getRelationshipsCreated()).isEqualTo(1);
+			var validationResult = migrations.validate();
+			assertThat(validationResult.getOutcome()).isEqualTo(ValidationResult.Outcome.VALID);
+
+			var currentChain = migrations.info();
+			assertThat(currentChain.getElements()).map(MigrationChain.Element::getInstalledBy)
+				.map(Optional::orElseThrow)
+				.containsOnly("msimons/neo4j");
+
+			assertThat(currentChain.getElements()).map(MigrationChain.Element::getSource)
+				.containsOnly("V0001__delete_old_data.cypher", "V0002__create_new_data.cypher");
+		}
 
 		@Test
 		void shouldCreateAProperChain(@TempDir File dir) throws IOException {

--- a/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ValidateIT.java
+++ b/neo4j-migrations-core/src/test/java/ac/simons/neo4j/migrations/core/ValidateIT.java
@@ -97,6 +97,45 @@ class ValidateIT extends TestBase {
 	}
 
 	@Test
+	void duplicateLocalVersion() {
+		var migrations = new Migrations(
+				MigrationsConfig.builder().withLocationsToScan("/some/changeset_w_duplicates").build(), this.driver);
+		var result = migrations.validate();
+		assertThat(result.getOutcome()).isEqualTo(ValidationResult.Outcome.DUPLICATE_VERSION);
+		assertThat(result.getWarnings()).containsExactly(
+				"Duplicate version '0001' (V0001__delete_old_data.cypher, V0001__delete_old_data2.cypher)");
+	}
+
+	@Test
+	void duplicateRemoteVersion() {
+
+		// Note: Those migrations must not have a property `migrationTarget`, otherwise
+		// unique_version___Neo4jMigration
+		// will catch those and prevent the invalid database state.
+		try (var session = this.driver.session()) {
+			session
+				.run("""
+						CREATE (:`__Neo4jMigration` {version:"BASELINE"})
+						-[:MIGRATED_TO {connectedAs:"neo4j",at:$when,in:$duration,by:"msimons"}]->
+						     (:`__Neo4jMigration` {checksum:"1100083332",description:"delete old data",source:"V0001__delete_old_data_a.cypher",type:"CYPHER",version:"0001"})
+						-[:MIGRATED_TO {connectedAs:"neo4j",at:$when,in:$duration,by:"msimons"}]->
+						     (:`__Neo4jMigration` {checksum:"1100083332",description:"delete old data",source:"V0001__delete_old_data_b.cypher",type:"CYPHER",version:"0001"})
+						-[:MIGRATED_TO {connectedAs:"neo4j",at:$when,in:$duration,by:"msimons"}]->
+						     (:`__Neo4jMigration` {checksum:"3226785110",description:"create new data",source:"V0002__create_new_data.cypher",type:"CYPHER",version:"0002"})
+						""",
+						Values.parameters("when", ZonedDateTime.now(), "duration", Duration.ofSeconds(23)))
+				.consume();
+		}
+
+		var migrations = new Migrations(MigrationsConfig.builder().withLocationsToScan("/some/changeset").build(),
+				this.driver);
+		var result = migrations.validate();
+		assertThat(result.getOutcome()).isEqualTo(ValidationResult.Outcome.DUPLICATE_VERSION);
+		assertThat(result.getWarnings()).containsExactly(
+				"Duplicate version '0001' (V0001__delete_old_data_a.cypher, V0001__delete_old_data_b.cypher)");
+	}
+
+	@Test
 	void wrongChecksum() {
 
 		try (Session session = this.driver.session()) {

--- a/neo4j-migrations-examples/neo4j-migrations-cluster-tests/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-cluster-tests/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-cluster-tests</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb-testharness/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb-testharness</artifactId>

--- a/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
+++ b/neo4j-migrations-examples/neo4j-migrations-examples-sb/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-examples</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples-sb</artifactId>

--- a/neo4j-migrations-examples/pom.xml
+++ b/neo4j-migrations-examples/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-examples</artifactId>

--- a/neo4j-migrations-maven-plugin/pom.xml
+++ b/neo4j-migrations-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-maven-plugin</artifactId>

--- a/neo4j-migrations-quarkus-parent/deployment/pom.xml
+++ b/neo4j-migrations-quarkus-parent/deployment/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-deployment</artifactId>

--- a/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
+++ b/neo4j-migrations-quarkus-parent/integration-tests/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-integration-tests</artifactId>
@@ -73,6 +73,7 @@
 			<plugin>
 				<groupId>io.quarkus</groupId>
 				<artifactId>quarkus-maven-plugin</artifactId>
+				<extensions>true</extensions>
 				<executions>
 					<execution>
 						<goals>

--- a/neo4j-migrations-quarkus-parent/pom.xml
+++ b/neo4j-migrations-quarkus-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus-parent</artifactId>

--- a/neo4j-migrations-quarkus-parent/runtime/pom.xml
+++ b/neo4j-migrations-quarkus-parent/runtime/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-quarkus-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-quarkus</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-autoconfigure</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/neo4j-migrations-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter</artifactId>

--- a/neo4j-migrations-spring-boot-starter-parent/pom.xml
+++ b/neo4j-migrations-spring-boot-starter-parent/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-spring-boot-starter-parent</artifactId>

--- a/neo4j-migrations-test-resources/pom.xml
+++ b/neo4j-migrations-test-resources/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-resources</artifactId>

--- a/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0001__delete_old_data.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0001__delete_old_data.cypher
@@ -1,0 +1,1 @@
+MATCH (n:BrokenData) DETACH DELETE n;

--- a/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0001__delete_old_data2.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0001__delete_old_data2.cypher
@@ -1,0 +1,1 @@
+MATCH (n:BrokenData) DETACH DELETE n;

--- a/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0002__create_new_data.cypher
+++ b/neo4j-migrations-test-resources/src/main/resources/some/changeset_w_duplicates/V0002__create_new_data.cypher
@@ -1,0 +1,3 @@
+CREATE (n:FixedData) RETURN n;
+MATCH (n) RETURN count(n) AS foobar;
+

--- a/neo4j-migrations-test-results/pom.xml
+++ b/neo4j-migrations-test-results/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>eu.michael-simons.neo4j</groupId>
 		<artifactId>neo4j-migrations-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>neo4j-migrations-test-results</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>eu.michael-simons.neo4j</groupId>
 	<artifactId>neo4j-migrations-parent</artifactId>
-	<version>4.0.3-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Neo4j Migrations</name>


### PR DESCRIPTION
This adds validation of uniqueness of versions to the discovery and validation phase of the applied migrations. Also, it enhances the repair command with the suggested fix in #1988. This fix is done before all other fixes, so that the expected list of versions are aligned.

Also, while it would be possible to fix for all duplicates within one Cypher statement, we don’t, as we cannot ensure the same order of migration versions (lexicographic or semantic order).

Closes #1988.

Signed-off-by: Michael Simons <michael@simons.ac>
