### PR TITLE
fix: Report Neo4j error code and message for DatabaseException, not just ClientException.

### DIFF
--- a/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
+++ b/neo4j-migrations-cli/src/main/java/ac/simons/neo4j/migrations/cli/ConnectedCommand.java
@@ -25,8 +25,8 @@ import ac.simons.neo4j.migrations.core.catalog.Renderer;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.exceptions.AuthenticationException;
-import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.FatalDiscoveryException;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import picocli.CommandLine;
 
@@ -34,6 +34,7 @@ import picocli.CommandLine;
  * Base class for a connected command.
  *
  * @author Michael J. Simons
+ * @author Vladas Diržys
  * @since 0.0.5
  */
 abstract class ConnectedCommand implements Callable<Integer> {
@@ -92,9 +93,9 @@ abstract class ConnectedCommand implements Callable<Integer> {
 		}
 		catch (MigrationsException ex) {
 			Throwable cause = ex.getCause();
-			if (cause instanceof ClientException ce) {
+			if (cause instanceof Neo4jException ne) {
 				MigrationsCli.LOGGER.log(Level.SEVERE, "{0}{1}\t{2}: {3}",
-						new Object[] { ex.getMessage(), System.lineSeparator(), ce.code(), cause.getMessage() });
+						new Object[] { ex.getMessage(), System.lineSeparator(), ne.code(), cause.getMessage() });
 			}
 			else if (isCatalogException(cause)) {
 				MigrationsCli.LOGGER.log(Level.SEVERE, "{0}: {1}",

--- a/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ExceptionHandlingTests.java
+++ b/neo4j-migrations-cli/src/test/java/ac/simons/neo4j/migrations/cli/ExceptionHandlingTests.java
@@ -24,6 +24,7 @@ import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.DatabaseException;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Michael J. Simons
+ * @author Vladas Diržys
  */
 class ExceptionHandlingTests {
 
@@ -69,14 +71,34 @@ class ExceptionHandlingTests {
 				}
 			};
 
+			// GH-2003: A constraint creation failure on existing data is a
+			// DatabaseException,
+			// not a ClientException. Its code and message must still be reported.
+			ConnectedCommand cmd3 = new ConnectedCommand() {
+				@Override
+				MigrationsCli getParent() {
+					return cli;
+				}
+
+				@Override
+				Integer withMigrations(Migrations migrations) {
+					throw new MigrationsException("Could not apply migration: 5.",
+							new DatabaseException("Neo.DatabaseError.Schema.ConstraintCreationFailed",
+									"Unable to create Constraint( ... ): existing data is not unique."));
+				}
+			};
+
 			cmd.call();
 			cmd2.call();
+			cmd3.call();
 			System.out.flush();
 		});
 
 		assertThat(result).isEqualTo("Oh wie schade." + System.lineSeparator()
 				+ "Could not apply migration: 0020 (\"Create unique movie title\")." + System.lineSeparator()
-				+ "\tNeo4j.YouMessedUp: This was not valid." + System.lineSeparator());
+				+ "\tNeo4j.YouMessedUp: This was not valid." + System.lineSeparator() + "Could not apply migration: 5."
+				+ System.lineSeparator() + "\tNeo.DatabaseError.Schema.ConstraintCreationFailed: "
+				+ "Unable to create Constraint( ... ): existing data is not unique." + System.lineSeparator());
 	}
 
 }


### PR DESCRIPTION
Closes #2003.

`ConnectedCommand` matched only `ClientException` when formatting a failed migration's cause, so `DatabaseException`s (e.g. `Neo.DatabaseError.Schema.ConstraintCreationFailed` when a unique constraint can't be created over existing data) were logged without their error code or detail message — leaving developers to guess the real reason for the failure.

This widens the match to the common supertype `Neo4jException`, which exposes `code()` for both client- and database-side errors. The detail is reported at `SEVERE` (no `-v` required) as a formatted `code: message` line — no stack trace.

Added a test case covering a `DatabaseException` cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)